### PR TITLE
PR1: SPI interfaces + minimal lakehouse-iceberg plugin skeleton

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/exec/ExternalScanContext.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/exec/ExternalScanContext.java
@@ -1,0 +1,62 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Carries the resolved scan context from an external table plugin (e.g., Iceberg)
+ * to the native execution backend (e.g., DataFusion).
+ */
+public class ExternalScanContext {
+    private final String tableName;
+    private final List<String> dataFilePaths;
+    private final String sqlQuery;
+    private final Map<String, String> storageConfig;
+
+    /**
+     * Creates a new scan context.
+     *
+     * @param tableName      table name matching the query plan
+     * @param dataFilePaths  pruned data file paths to scan
+     * @param sqlQuery       SQL query string for the target execution engine
+     * @param storageConfig  storage configuration (S3 region, bucket, credentials)
+     */
+    public ExternalScanContext(String tableName, List<String> dataFilePaths, String sqlQuery, Map<String, String> storageConfig) {
+        this.tableName = tableName;
+        this.dataFilePaths = dataFilePaths;
+        this.sqlQuery = sqlQuery;
+        this.storageConfig = storageConfig;
+    }
+
+    /** Table name as registered in the Calcite schema. */
+    public String getTableName() {
+        return tableName;
+    }
+
+    /** Pruned list of data file paths (e.g., s3://bucket/data/file.parquet). */
+    public List<String> getDataFilePaths() {
+        return dataFilePaths;
+    }
+
+    /** SQL query string for the target execution engine. */
+    public String getSqlQuery() {
+        return sqlQuery;
+    }
+
+    /**
+     * Storage configuration for the external data source.
+     * Keys: s3Region, s3Bucket, s3AccessKeyId (optional), s3SecretAccessKey (optional),
+     *        s3SessionToken (optional), s3Endpoint (optional).
+     */
+    public Map<String, String> getStorageConfig() {
+        return storageConfig;
+    }
+}

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/exec/ExternalTableExecutor.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/exec/ExternalTableExecutor.java
@@ -1,0 +1,40 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.exec;
+
+import org.apache.calcite.rel.RelNode;
+import org.opensearch.analytics.schema.ExternalTable;
+
+/**
+ * Prepares a scan context for queries against external (non-OpenSearch) tables.
+ * Implementations are discovered by {@link org.opensearch.plugins.ExtensiblePlugin.ExtensionLoader}
+ * and injected into the QueryPlanExecutor. The actual execution is delegated to the analytics backend.
+ *
+ * @opensearch.internal
+ */
+public interface ExternalTableExecutor {
+
+    /**
+     * Returns whether this executor handles the given external table.
+     * Used by the plan executor to route queries when multiple format plugins are installed.
+     *
+     * @param externalTable the external table to check
+     * @return {@code true} if this executor can plan scans for the table
+     */
+    boolean supports(ExternalTable externalTable);
+
+    /**
+     * Prepares a scan context for an external table query.
+     *
+     * @param logicalPlan   the optimized Calcite logical plan
+     * @param externalTable the external table found in the plan
+     * @return scan context for native execution
+     */
+    ExternalScanContext prepareScan(RelNode logicalPlan, ExternalTable externalTable);
+}

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/schema/ExternalTable.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/schema/ExternalTable.java
@@ -1,0 +1,25 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.schema;
+
+/**
+ * Marker interface for external (non-OpenSearch) tables in the Calcite schema.
+ * Implementations carry catalog metadata needed by {@link org.opensearch.analytics.exec.ExternalTableExecutor}
+ * to plan and execute scans against external data sources (e.g., Iceberg, Delta Lake).
+ *
+ * @opensearch.internal
+ */
+public interface ExternalTable {
+
+    /** Returns the fully-qualified table name in the external catalog. */
+    String qualifiedName();
+
+    /** Returns the table format identifier (e.g., "iceberg", "delta", "hudi"). */
+    String format();
+}

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/schema/SchemaContributor.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/schema/SchemaContributor.java
@@ -1,0 +1,36 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.analytics.schema;
+
+import org.apache.calcite.schema.SchemaPlus;
+
+/**
+ * SPI for plugins that contribute additional tables to the Calcite schema.
+ * <p>
+ * Implementations are discovered by the analytics-engine hub via
+ * {@link org.opensearch.plugins.ExtensiblePlugin.ExtensionLoader} and called
+ * after the base OpenSearch index schema is built. This allows external data
+ * source plugins (e.g., Iceberg, Delta Lake) to register their tables into
+ * the Calcite schema without creating compile-time dependencies from the
+ * analytics engine to those plugins.
+ *
+ * @opensearch.internal
+ */
+@FunctionalInterface
+public interface SchemaContributor {
+
+    /**
+     * Adds tables to the given Calcite schema.
+     *
+     * @param schema       the mutable Calcite schema to enrich
+     * @param clusterState the current cluster state (opaque Object to avoid
+     *                     server dependency in the library)
+     */
+    void contributeSchema(SchemaPlus schema, Object clusterState);
+}

--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsSearchBackendPlugin.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/spi/AnalyticsSearchBackendPlugin.java
@@ -8,10 +8,26 @@
 
 package org.opensearch.analytics.spi;
 
+import org.opensearch.analytics.backend.EngineResultStream;
+import org.opensearch.analytics.exec.ExternalScanContext;
+
 /**
  * SPI extension point for back-end query engines for query planning and execution capabilities
  * as needed by the {@link org.opensearch.analytics.exec.QueryPlanExecutor}
  */
 public interface AnalyticsSearchBackendPlugin extends SearchExecEngineProvider {
 
+    /**
+     * Executes a query against remote data files using the native engine.
+     * The scan context contains the SQL query, file paths, and storage config.
+     * The returned stream is {@link java.io.Closeable} — callers must close it
+     * to release native resources (Arrow allocators, stream handles, etc.).
+     *
+     * @param scanContext the resolved scan context from an external table plugin
+     * @return a closeable stream of result batches
+     * @throws UnsupportedOperationException if this backend does not support remote execution
+     */
+    default EngineResultStream executeRemoteQuery(ExternalScanContext scanContext) {
+        throw new UnsupportedOperationException(name() + " does not support remote query execution");
+    }
 }

--- a/sandbox/plugins/lakehouse-iceberg/build.gradle
+++ b/sandbox/plugins/lakehouse-iceberg/build.gradle
@@ -1,0 +1,20 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+opensearchplugin {
+    name = 'lakehouse-iceberg'
+    description = 'Read external Apache Iceberg tables via PPL and SQL'
+    classname = 'org.opensearch.lakehouse.LakehousePlugin'
+    extendedPlugins = ['analytics-engine']
+}
+
+dependencies {
+    // Analytics engine and framework (compile-only, provided at runtime by analytics-engine plugin)
+    compileOnly project(':sandbox:plugins:analytics-engine')
+    compileOnly project(':sandbox:libs:analytics-framework')
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/LakehousePlugin.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/LakehousePlugin.java
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse;
+
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.schema.SchemaPlus;
+import org.opensearch.analytics.exec.ExternalScanContext;
+import org.opensearch.analytics.exec.ExternalTableExecutor;
+import org.opensearch.analytics.schema.ExternalTable;
+import org.opensearch.analytics.schema.SchemaContributor;
+import org.opensearch.plugins.Plugin;
+
+/**
+ * Lakehouse plugin that enables reading external Apache Iceberg tables via SQL and PPL.
+ * <p>
+ * This plugin contributes Iceberg tables to the Calcite schema and prepares scan contexts
+ * for the analytics execution engine. Actual query execution is delegated to the
+ * analytics-backend-datafusion plugin.
+ * <p>
+ * Implements both {@link SchemaContributor} (to register Iceberg tables into Calcite) and
+ * {@link ExternalTableExecutor} (to build scan plans for those tables). Both interfaces are
+ * discovered via ExtensiblePlugin.ExtensionLoader by the analytics-engine.
+ */
+public class LakehousePlugin extends Plugin implements SchemaContributor, ExternalTableExecutor {
+
+    /** Creates a new LakehousePlugin instance. */
+    public LakehousePlugin() {}
+
+    @Override
+    public boolean supports(ExternalTable externalTable) {
+        return "iceberg".equals(externalTable.format());
+    }
+
+    @Override
+    public void contributeSchema(SchemaPlus schema, Object clusterState) {
+        // Will be implemented in PR2 (catalog registration + schema discovery)
+    }
+
+    @Override
+    public ExternalScanContext prepareScan(RelNode logicalPlan, ExternalTable externalTable) {
+        // Will be implemented in PR4 (scan planning)
+        throw new UnsupportedOperationException("Iceberg scan planning not yet implemented");
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/package-info.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Lakehouse plugin for reading external Apache Iceberg tables via SQL and PPL.
+ */
+package org.opensearch.lakehouse;

--- a/sandbox/plugins/lakehouse-iceberg/src/main/plugin-metadata/plugin-security.policy
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/plugin-metadata/plugin-security.policy
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+grant {
+    // Network access for Glue catalog and S3 data reads
+    permission java.net.SocketPermission "*", "connect,resolve";
+};

--- a/sandbox/plugins/lakehouse-iceberg/src/main/resources/META-INF/services/org.opensearch.analytics.exec.ExternalTableExecutor
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/resources/META-INF/services/org.opensearch.analytics.exec.ExternalTableExecutor
@@ -1,0 +1,1 @@
+org.opensearch.lakehouse.LakehousePlugin

--- a/sandbox/plugins/lakehouse-iceberg/src/main/resources/META-INF/services/org.opensearch.analytics.schema.SchemaContributor
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/resources/META-INF/services/org.opensearch.analytics.schema.SchemaContributor
@@ -1,0 +1,1 @@
+org.opensearch.lakehouse.LakehousePlugin

--- a/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/LakehousePluginTests.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/LakehousePluginTests.java
@@ -1,0 +1,22 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+
+public class LakehousePluginTests extends OpenSearchTestCase {
+
+    public void testPluginCreation() throws IOException {
+        try (LakehousePlugin plugin = new LakehousePlugin()) {
+            assertNotNull(plugin);
+        }
+    }
+}


### PR DESCRIPTION
## Context: OpenSearch Analytics Sandbox Architecture

The analytics sandbox is a plugin-based query execution framework:

```
                        ┌──────────────────────────────────────┐
                        │         analytics-framework          │
                        │  (shared library — interfaces only)  │
                        │                                      │
                        │  QueryPlanExecutor  SchemaProvider    │
                        │  SearchExecEngine   EngineContext     │
                        │  AnalyticsSearchBackendPlugin (SPI)  │
                        │  ExternalTable ◄── NEW               │
                        │  ExternalTableExecutor ◄── NEW       │
                        │  ExternalScanContext ◄── NEW         │
                        │  SchemaContributor ◄── NEW           │
                        └──────────┬───────────────────────────┘
                                   │ depends on
          ┌────────────────────────┼──────────────────────────┐
          │                        │                          │
          ▼                        ▼                          ▼
┌──────────────────┐  ┌────────────────────────┐  ┌─────────────────────┐
│ dsl-query-       │  │   analytics-engine      │  │ lakehouse-iceberg   │
│ executor         │  │   (hub plugin)          │  │ (NEW — this PR)     │
│                  │  │                          │  │                     │
│ Intercepts       │  │ ExtensiblePlugin:        │  │ SchemaContributor:  │
│ _search DSL      │  │  discovers backends     │  │  adds Iceberg       │
│ → Calcite plan   │  │  + schema contributors  │  │  tables to schema   │
│ → delegates to   │  │                          │  │                     │
│   PlanExecutor   │  │ DefaultPlanExecutor:     │  │ ExternalTable-      │
│                  │  │  routes plan to backend  │  │  Executor:          │
│                  │  │  (index OR external)     │  │  builds scan plan   │
└──────────────────┘  │                          │  │  (files, SQL, creds)│
                      │ OpenSearchSchemaBuilder: │  │                     │
                      │  builds schema from      │  │ supports("iceberg") │
                      │  index mappings          │  └─────────────────────┘
                      └────────────┬─────────────┘
                                   │ SPI discovery
                    ┌──────────────┴──────────────┐
                    ▼                              ▼
          ┌──────────────────┐          ┌──────────────────┐
          │ analytics-       │          │ analytics-       │
          │ backend-         │          │ backend-lucene   │
          │ datafusion       │          │ (stub)           │
          │                  │          └──────────────────┘
          │ DataFusion Rust  │
          │ engine via JNI   │
          │ Tokio runtime    │
          │ Arrow streams    │
          │ Memory pool +    │
          │ spill-to-disk    │
          │                  │
          │ executeRemote-   │
          │ Query() ◄── NEW  │
          └──────────────────┘
```

**Indexing path** (not shown): `composite-engine` orchestrates multi-format writes (Lucene primary + Parquet secondary via `parquet-data-format`).

### What each component does

| Component | Type | Role |
|-----------|------|------|
| **analytics-framework** | Library | Shared contracts — `QueryPlanExecutor`, `SearchExecEngine`, `SchemaProvider`, `EngineContext`, result streaming types, JNI `NativeHandle` base |
| **analytics-engine** | Hub Plugin | `ExtensiblePlugin` that discovers backends and schema contributors via SPI. `DefaultPlanExecutor` routes Calcite plans to the right backend. `OpenSearchSchemaBuilder` creates the Calcite schema from index mappings |
| **analytics-backend-datafusion** | Backend Plugin | Apache DataFusion (Rust) native execution via JNI. Manages Tokio runtime, memory pool, disk spill. Converts plans to Substrait, executes natively, streams results via Arrow C Data Interface |
| **analytics-backend-lucene** | Backend Plugin | Lucene `DirectoryReader` backend (minimal stub for future expansion) |
| **dsl-query-executor** | Front-end Plugin | Intercepts `_search` requests via `SearchActionFilter`, converts DSL to Calcite RelNode, delegates to `QueryPlanExecutor` |
| **composite-engine** | Indexing Plugin | Multi-format write orchestrator — routes documents to Lucene (primary) + Parquet (secondary) |
| **parquet-data-format** | Indexing Plugin | Parquet data format for composite engine — Arrow schema conversion, Rust Parquet writer via JNI |

### Why these extensions are needed

The current analytics engine is **hardwired to OpenSearch indexes**:
- `OpenSearchSchemaBuilder` only sees index mappings — no way for external catalogs to contribute tables
- `DefaultPlanExecutor` resolves tables as local shards via `IndicesService` — Iceberg tables have no shards
- The DataFusion backend only executes via shard readers — no path for remote file-based execution

The new interfaces create a **clean plugin boundary** so that `lakehouse-iceberg` can participate in query execution without compile-time coupling:

| New Interface | Gap it fills |
|---------------|-------------|
| `SchemaContributor` | Lets plugins inject tables into the Calcite schema (Iceberg, Delta Lake, Hudi) |
| `ExternalTable` + `format()` | Marks non-index tables so the plan executor can route to the right executor |
| `ExternalTableExecutor` + `supports()` | Builds scan contexts (file paths, SQL, S3 creds) — dispatched by format string |
| `ExternalScanContext` | DTO carrying everything the backend needs for remote file execution |
| `executeRemoteQuery()` | Alternative backend execution path — SQL + files instead of shard reader |

### Extensibility

The design supports multiple formats and storage backends:
- A Delta Lake plugin would implement `SchemaContributor` + `ExternalTableExecutor` with `supports("delta")`
- Storage config is `Map<String, String>` — works for S3, GCS, Azure, HDFS
- The plan executor routes by calling `supports()` on each registered executor

---

## Summary
- Add extension point interfaces in `analytics-framework` for external data source plugins
- Create minimal `lakehouse-iceberg` plugin skeleton with SPI wiring

## Files changed (294 lines, 12 files)

### analytics-framework (SPI interfaces)
| File | Change |
|------|--------|
| `ExternalScanContext.java` | New — scan context DTO (table, files, SQL, storage config) |
| `ExternalTableExecutor.java` | New — scan preparation interface with `supports()` routing |
| `ExternalTable.java` | New — marker interface with `format()` for multi-format dispatch |
| `SchemaContributor.java` | New — schema enrichment SPI |
| `AnalyticsSearchBackendPlugin.java` | Modified — add `executeRemoteQuery()` default method |

### lakehouse-iceberg (plugin skeleton)
| File | Change |
|------|--------|
| `build.gradle` | New — minimal deps (compileOnly on analytics-engine/framework) |
| `LakehousePlugin.java` | New — implements SchemaContributor + ExternalTableExecutor, `supports("iceberg")` |
| `package-info.java` | New — package javadoc |
| `plugin-security.policy` | New — SocketPermission for network access |
| `META-INF/services/*` | New — SPI wiring for both interfaces |
| `LakehousePluginTests.java` | New — basic plugin creation test |

## Test plan
- [x] `./gradlew :sandbox:libs:analytics-framework:check` passes
- [x] `./gradlew :sandbox:plugins:lakehouse-iceberg:check` passes (compile, spotless, javadoc, jarHell, test)
- [x] No jar-hell issues
- [x] Plugin bundles successfully (`assemble`)

## PR chain
This is PR 1 of 8 in the lakehouse-iceberg decomposition:
1. **PR1: SPI interfaces + plugin skeleton** ← this PR
2. PR2: Cluster state + REST APIs (register catalog/table)
3. PR3: Iceberg catalog connector (Glue/S3 integration)
4. PR4: Scan planning (predicate pushdown, file pruning)
5. PR5: DataFusion backend integration (SQL generation + JNI execution)
6. PR6: Calcite schema integration (wiring into analytics-engine)
7. PR7: Integration tests
8. PR8: ClickBench benchmarking