### PR TITLE
feat(lakehouse): define index and credential settings for Iceberg tables

### DIFF
--- a/sandbox/plugins/lakehouse-iceberg/build.gradle
+++ b/sandbox/plugins/lakehouse-iceberg/build.gradle
@@ -14,6 +14,9 @@ opensearchplugin {
 }
 
 dependencies {
+    // Server APIs (Plugin, Settings, SecureSetting — provided at runtime)
+    compileOnly project(':server')
+
     // Analytics engine and framework (compile-only, provided at runtime by analytics-engine plugin)
     compileOnly project(':sandbox:plugins:analytics-engine')
     compileOnly project(':sandbox:libs:analytics-framework')

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/LakehousePlugin.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/LakehousePlugin.java
@@ -14,14 +14,20 @@ import org.opensearch.analytics.exec.ExternalScanContext;
 import org.opensearch.analytics.exec.ExternalTableExecutor;
 import org.opensearch.analytics.schema.ExternalTable;
 import org.opensearch.analytics.schema.SchemaContributor;
+import org.opensearch.common.settings.Setting;
 import org.opensearch.plugins.Plugin;
+
+import java.util.List;
 
 /**
  * Lakehouse plugin that enables reading external Apache Iceberg tables via SQL and PPL.
  * <p>
- * This plugin contributes Iceberg tables to the Calcite schema and prepares scan contexts
- * for the analytics execution engine. Actual query execution is delegated to the
- * analytics-backend-datafusion plugin.
+ * Iceberg tables are registered as OpenSearch indices with special settings
+ * ({@code index.lakehouse.enabled=true}), which gives them automatic security
+ * plugin integration (RBAC, DLS, FLS, audit logging).
+ * <p>
+ * Catalog configuration is stored in node-scoped settings ({@code lakehouse.catalog.{name}.*}),
+ * with credentials in the opensearch-keystore for security.
  * <p>
  * Implements both {@link SchemaContributor} (to register Iceberg tables into Calcite) and
  * {@link ExternalTableExecutor} (to build scan plans for those tables). Both interfaces are
@@ -33,18 +39,23 @@ public class LakehousePlugin extends Plugin implements SchemaContributor, Extern
     public LakehousePlugin() {}
 
     @Override
+    public List<Setting<?>> getSettings() {
+        return LakehouseSettings.all();
+    }
+
+    @Override
     public boolean supports(ExternalTable externalTable) {
         return "iceberg".equals(externalTable.format());
     }
 
     @Override
     public void contributeSchema(SchemaPlus schema, Object clusterState) {
-        // Will be implemented in PR2 (catalog registration + schema discovery)
+        // Will be implemented in a later PR (Iceberg catalog connector + schema discovery)
     }
 
     @Override
     public ExternalScanContext prepareScan(RelNode logicalPlan, ExternalTable externalTable) {
-        // Will be implemented in PR4 (scan planning)
+        // Will be implemented in a later PR (scan planning)
         throw new UnsupportedOperationException("Iceberg scan planning not yet implemented");
     }
 }

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/LakehousePlugin.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/LakehousePlugin.java
@@ -24,10 +24,12 @@ import java.util.List;
  * <p>
  * Iceberg tables are registered as OpenSearch indices with special settings
  * ({@code index.lakehouse.enabled=true}), which gives them automatic security
- * plugin integration (RBAC, DLS, FLS, audit logging).
+ * plugin integration (RBAC, DLS, FLS, audit logging). All table configuration
+ * (catalog type, region, warehouse, namespace, table) is index-scoped.
  * <p>
- * Catalog configuration is stored in node-scoped settings ({@code lakehouse.catalog.{name}.*}),
- * with credentials in the opensearch-keystore for security.
+ * Authentication supports three modes via {@code index.lakehouse.auth_type}:
+ * {@code role} (IAM assume-role), {@code keys} (keystore-backed credentials),
+ * or {@code default} (environment credentials chain).
  * <p>
  * Implements both {@link SchemaContributor} (to register Iceberg tables into Calcite) and
  * {@link ExternalTableExecutor} (to build scan plans for those tables). Both interfaces are

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/LakehouseSettings.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/LakehouseSettings.java
@@ -1,0 +1,135 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse;
+
+import org.opensearch.common.settings.SecureSetting;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Setting.Property;
+import org.opensearch.core.common.settings.SecureString;
+
+import java.util.List;
+
+/**
+ * Settings for the lakehouse plugin.
+ * <p>
+ * <b>Catalog settings</b> (node-scoped, from opensearch.yml / keystore):
+ * <pre>
+ *   lakehouse.catalog.{name}.type       — catalog type: glue, hadoop, rest
+ *   lakehouse.catalog.{name}.region     — AWS region (for Glue/S3)
+ *   lakehouse.catalog.{name}.warehouse  — warehouse path (s3:// or file://)
+ *   lakehouse.catalog.{name}.access_key — AWS access key (keystore)
+ *   lakehouse.catalog.{name}.secret_key — AWS secret key (keystore)
+ *   lakehouse.catalog.{name}.session_token — STS session token (keystore)
+ * </pre>
+ * <p>
+ * <b>Index settings</b> (per-index, set at index creation):
+ * <pre>
+ *   index.lakehouse.enabled   — marks this index as an external lakehouse table
+ *   index.lakehouse.catalog   — references a catalog name from the catalog settings
+ *   index.lakehouse.namespace — Iceberg namespace (e.g., Glue database name)
+ *   index.lakehouse.table     — Iceberg table name within the namespace
+ * </pre>
+ */
+public final class LakehouseSettings {
+
+    private LakehouseSettings() {}
+
+    // ── Catalog settings (node-scoped, from opensearch.yml / keystore) ──
+
+    /** Catalog type: glue, hadoop, rest. */
+    public static final Setting.AffixSetting<String> CATALOG_TYPE = Setting.affixKeySetting(
+        "lakehouse.catalog.",
+        "type",
+        key -> Setting.simpleString(key, Property.NodeScope)
+    );
+
+    /** AWS region for Glue/S3 access. */
+    public static final Setting.AffixSetting<String> CATALOG_REGION = Setting.affixKeySetting(
+        "lakehouse.catalog.",
+        "region",
+        key -> Setting.simpleString(key, Property.NodeScope)
+    );
+
+    /** Warehouse location (s3://bucket/path or file:///path). */
+    public static final Setting.AffixSetting<String> CATALOG_WAREHOUSE = Setting.affixKeySetting(
+        "lakehouse.catalog.",
+        "warehouse",
+        key -> Setting.simpleString(key, Property.NodeScope)
+    );
+
+    // ── Catalog secure settings (keystore-backed) ──
+
+    /** AWS access key ID (stored in opensearch-keystore). */
+    public static final Setting.AffixSetting<SecureString> CATALOG_ACCESS_KEY = Setting.affixKeySetting(
+        "lakehouse.catalog.",
+        "access_key",
+        key -> SecureSetting.secureString(key, null)
+    );
+
+    /** AWS secret access key (stored in opensearch-keystore). */
+    public static final Setting.AffixSetting<SecureString> CATALOG_SECRET_KEY = Setting.affixKeySetting(
+        "lakehouse.catalog.",
+        "secret_key",
+        key -> SecureSetting.secureString(key, null)
+    );
+
+    /** AWS STS session token (stored in opensearch-keystore, optional). */
+    public static final Setting.AffixSetting<SecureString> CATALOG_SESSION_TOKEN = Setting.affixKeySetting(
+        "lakehouse.catalog.",
+        "session_token",
+        key -> SecureSetting.secureString(key, null)
+    );
+
+    // ── Index settings (per-index, set at creation time) ──
+
+    /** Whether this index represents an external lakehouse table. */
+    public static final Setting<Boolean> INDEX_LAKEHOUSE_ENABLED = Setting.boolSetting(
+        "index.lakehouse.enabled",
+        false,
+        Property.IndexScope,
+        Property.Final
+    );
+
+    /** Name of the catalog this table belongs to. */
+    public static final Setting<String> INDEX_LAKEHOUSE_CATALOG = Setting.simpleString(
+        "index.lakehouse.catalog",
+        Property.IndexScope,
+        Property.Final
+    );
+
+    /** Iceberg namespace (e.g., Glue database name). */
+    public static final Setting<String> INDEX_LAKEHOUSE_NAMESPACE = Setting.simpleString(
+        "index.lakehouse.namespace",
+        Property.IndexScope,
+        Property.Final
+    );
+
+    /** Iceberg table name within the namespace. */
+    public static final Setting<String> INDEX_LAKEHOUSE_TABLE = Setting.simpleString(
+        "index.lakehouse.table",
+        Property.IndexScope,
+        Property.Final
+    );
+
+    /** Returns all settings to register with the plugin. */
+    public static List<Setting<?>> all() {
+        return List.of(
+            CATALOG_TYPE,
+            CATALOG_REGION,
+            CATALOG_WAREHOUSE,
+            CATALOG_ACCESS_KEY,
+            CATALOG_SECRET_KEY,
+            CATALOG_SESSION_TOKEN,
+            INDEX_LAKEHOUSE_ENABLED,
+            INDEX_LAKEHOUSE_CATALOG,
+            INDEX_LAKEHOUSE_NAMESPACE,
+            INDEX_LAKEHOUSE_TABLE
+        );
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/LakehouseSettings.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/LakehouseSettings.java
@@ -18,75 +18,31 @@ import java.util.List;
 /**
  * Settings for the lakehouse plugin.
  * <p>
- * <b>Catalog settings</b> (node-scoped, from opensearch.yml / keystore):
+ * <b>Index settings</b> (per-index, set at index creation time):
  * <pre>
- *   lakehouse.catalog.{name}.type       — catalog type: glue, hadoop, rest
- *   lakehouse.catalog.{name}.region     — AWS region (for Glue/S3)
- *   lakehouse.catalog.{name}.warehouse  — warehouse path (s3:// or file://)
- *   lakehouse.catalog.{name}.access_key — AWS access key (keystore)
- *   lakehouse.catalog.{name}.secret_key — AWS secret key (keystore)
- *   lakehouse.catalog.{name}.session_token — STS session token (keystore)
+ *   index.lakehouse.enabled        — marks this index as an external lakehouse table
+ *   index.lakehouse.type           — catalog type: glue, hadoop, rest
+ *   index.lakehouse.region         — AWS region (for Glue/S3)
+ *   index.lakehouse.warehouse      — warehouse path (s3:// or file://)
+ *   index.lakehouse.namespace      — Iceberg namespace (e.g., Glue database name)
+ *   index.lakehouse.table          — Iceberg table name within the namespace
+ *   index.lakehouse.auth_type      — authentication type: role, keys, default
+ *   index.lakehouse.role_arn       — IAM role ARN (for auth_type=role)
+ *   index.lakehouse.credential_key — keystore credential name (for auth_type=keys)
  * </pre>
  * <p>
- * <b>Index settings</b> (per-index, set at index creation):
+ * <b>Keystore credentials</b> (node-scoped, for auth_type=keys):
  * <pre>
- *   index.lakehouse.enabled   — marks this index as an external lakehouse table
- *   index.lakehouse.catalog   — references a catalog name from the catalog settings
- *   index.lakehouse.namespace — Iceberg namespace (e.g., Glue database name)
- *   index.lakehouse.table     — Iceberg table name within the namespace
+ *   lakehouse.credentials.{name}.access_key     — AWS access key (keystore)
+ *   lakehouse.credentials.{name}.secret_key     — AWS secret key (keystore)
+ *   lakehouse.credentials.{name}.session_token  — STS session token (keystore, optional)
  * </pre>
  */
 public final class LakehouseSettings {
 
     private LakehouseSettings() {}
 
-    // ── Catalog settings (node-scoped, from opensearch.yml / keystore) ──
-
-    /** Catalog type: glue, hadoop, rest. */
-    public static final Setting.AffixSetting<String> CATALOG_TYPE = Setting.affixKeySetting(
-        "lakehouse.catalog.",
-        "type",
-        key -> Setting.simpleString(key, Property.NodeScope)
-    );
-
-    /** AWS region for Glue/S3 access. */
-    public static final Setting.AffixSetting<String> CATALOG_REGION = Setting.affixKeySetting(
-        "lakehouse.catalog.",
-        "region",
-        key -> Setting.simpleString(key, Property.NodeScope)
-    );
-
-    /** Warehouse location (s3://bucket/path or file:///path). */
-    public static final Setting.AffixSetting<String> CATALOG_WAREHOUSE = Setting.affixKeySetting(
-        "lakehouse.catalog.",
-        "warehouse",
-        key -> Setting.simpleString(key, Property.NodeScope)
-    );
-
-    // ── Catalog secure settings (keystore-backed) ──
-
-    /** AWS access key ID (stored in opensearch-keystore). */
-    public static final Setting.AffixSetting<SecureString> CATALOG_ACCESS_KEY = Setting.affixKeySetting(
-        "lakehouse.catalog.",
-        "access_key",
-        key -> SecureSetting.secureString(key, null)
-    );
-
-    /** AWS secret access key (stored in opensearch-keystore). */
-    public static final Setting.AffixSetting<SecureString> CATALOG_SECRET_KEY = Setting.affixKeySetting(
-        "lakehouse.catalog.",
-        "secret_key",
-        key -> SecureSetting.secureString(key, null)
-    );
-
-    /** AWS STS session token (stored in opensearch-keystore, optional). */
-    public static final Setting.AffixSetting<SecureString> CATALOG_SESSION_TOKEN = Setting.affixKeySetting(
-        "lakehouse.catalog.",
-        "session_token",
-        key -> SecureSetting.secureString(key, null)
-    );
-
-    // ── Index settings (per-index, set at creation time) ──
+    // ── Index settings (per-index, immutable after creation) ──
 
     /** Whether this index represents an external lakehouse table. */
     public static final Setting<Boolean> INDEX_LAKEHOUSE_ENABLED = Setting.boolSetting(
@@ -96,9 +52,23 @@ public final class LakehouseSettings {
         Property.Final
     );
 
-    /** Name of the catalog this table belongs to. */
-    public static final Setting<String> INDEX_LAKEHOUSE_CATALOG = Setting.simpleString(
-        "index.lakehouse.catalog",
+    /** Catalog type: glue, hadoop, rest. */
+    public static final Setting<String> INDEX_LAKEHOUSE_TYPE = Setting.simpleString(
+        "index.lakehouse.type",
+        Property.IndexScope,
+        Property.Final
+    );
+
+    /** AWS region for Glue/S3 access. */
+    public static final Setting<String> INDEX_LAKEHOUSE_REGION = Setting.simpleString(
+        "index.lakehouse.region",
+        Property.IndexScope,
+        Property.Final
+    );
+
+    /** Warehouse location (s3://bucket/path or file:///path). */
+    public static final Setting<String> INDEX_LAKEHOUSE_WAREHOUSE = Setting.simpleString(
+        "index.lakehouse.warehouse",
         Property.IndexScope,
         Property.Final
     );
@@ -117,19 +87,65 @@ public final class LakehouseSettings {
         Property.Final
     );
 
+    /** Authentication type: role, keys, or default. */
+    public static final Setting<String> INDEX_LAKEHOUSE_AUTH_TYPE = Setting.simpleString(
+        "index.lakehouse.auth_type",
+        Property.IndexScope,
+        Property.Final
+    );
+
+    /** IAM role ARN for assume-role authentication (auth_type=role). */
+    public static final Setting<String> INDEX_LAKEHOUSE_ROLE_ARN = Setting.simpleString(
+        "index.lakehouse.role_arn",
+        Property.IndexScope,
+        Property.Final
+    );
+
+    /** Keystore credential name for static key authentication (auth_type=keys). */
+    public static final Setting<String> INDEX_LAKEHOUSE_CREDENTIAL_KEY = Setting.simpleString(
+        "index.lakehouse.credential_key",
+        Property.IndexScope,
+        Property.Final
+    );
+
+    // ── Keystore credentials (node-scoped, for auth_type=keys) ──
+
+    /** AWS access key ID (stored in opensearch-keystore). */
+    public static final Setting.AffixSetting<SecureString> CREDENTIAL_ACCESS_KEY = Setting.affixKeySetting(
+        "lakehouse.credentials.",
+        "access_key",
+        key -> SecureSetting.secureString(key, null)
+    );
+
+    /** AWS secret access key (stored in opensearch-keystore). */
+    public static final Setting.AffixSetting<SecureString> CREDENTIAL_SECRET_KEY = Setting.affixKeySetting(
+        "lakehouse.credentials.",
+        "secret_key",
+        key -> SecureSetting.secureString(key, null)
+    );
+
+    /** AWS STS session token (stored in opensearch-keystore, optional). */
+    public static final Setting.AffixSetting<SecureString> CREDENTIAL_SESSION_TOKEN = Setting.affixKeySetting(
+        "lakehouse.credentials.",
+        "session_token",
+        key -> SecureSetting.secureString(key, null)
+    );
+
     /** Returns all settings to register with the plugin. */
     public static List<Setting<?>> all() {
         return List.of(
-            CATALOG_TYPE,
-            CATALOG_REGION,
-            CATALOG_WAREHOUSE,
-            CATALOG_ACCESS_KEY,
-            CATALOG_SECRET_KEY,
-            CATALOG_SESSION_TOKEN,
             INDEX_LAKEHOUSE_ENABLED,
-            INDEX_LAKEHOUSE_CATALOG,
+            INDEX_LAKEHOUSE_TYPE,
+            INDEX_LAKEHOUSE_REGION,
+            INDEX_LAKEHOUSE_WAREHOUSE,
             INDEX_LAKEHOUSE_NAMESPACE,
-            INDEX_LAKEHOUSE_TABLE
+            INDEX_LAKEHOUSE_TABLE,
+            INDEX_LAKEHOUSE_AUTH_TYPE,
+            INDEX_LAKEHOUSE_ROLE_ARN,
+            INDEX_LAKEHOUSE_CREDENTIAL_KEY,
+            CREDENTIAL_ACCESS_KEY,
+            CREDENTIAL_SECRET_KEY,
+            CREDENTIAL_SESSION_TOKEN
         );
     }
 }


### PR DESCRIPTION
## Summary

Defines the settings model for registering external Iceberg tables as OpenSearch indices. Each Iceberg table is represented by a native OpenSearch index with `index.lakehouse.*` settings — this gives automatic security plugin integration (RBAC, DLS, FLS, audit logging) with zero custom infrastructure.

**Index settings** (per-index, immutable after creation):

| Setting | Description |
|---------|-------------|
| `index.lakehouse.enabled` | Marks this index as an external lakehouse table |
| `index.lakehouse.type` | Catalog type: `glue`, `hadoop`, `rest` |
| `index.lakehouse.region` | AWS region (for Glue/S3) |
| `index.lakehouse.warehouse` | Warehouse path (`s3://` or `file://`) |
| `index.lakehouse.namespace` | Iceberg namespace (e.g., Glue database name) |
| `index.lakehouse.table` | Iceberg table name within the namespace |
| `index.lakehouse.auth_type` | Authentication: `role`, `keys`, or `default` |
| `index.lakehouse.role_arn` | IAM role ARN (for `auth_type=role`) |
| `index.lakehouse.credential_key` | Keystore credential name (for `auth_type=keys`) |

**Keystore credentials** (node-scoped, for `auth_type=keys`):

| Setting | Description |
|---------|-------------|
| `lakehouse.credentials.{name}.access_key` | AWS access key ID |
| `lakehouse.credentials.{name}.secret_key` | AWS secret access key |
| `lakehouse.credentials.{name}.session_token` | STS session token (optional) |

### Authentication modes

**Cloud (primary)** — IAM assume-role, no node-level config needed:
```json
PUT /my_iceberg_table
{
  "settings": {
    "index.lakehouse.enabled": true,
    "index.lakehouse.type": "glue",
    "index.lakehouse.region": "us-west-2",
    "index.lakehouse.warehouse": "s3://my-bucket/warehouse",
    "index.lakehouse.namespace": "my_database",
    "index.lakehouse.table": "my_table",
    "index.lakehouse.auth_type": "role",
    "index.lakehouse.role_arn": "arn:aws:iam::123456789012:role/iceberg-reader"
  }
}
```

**Open source** — keystore-backed static credentials:
```json
PUT /my_iceberg_table
{
  "settings": {
    "index.lakehouse.enabled": true,
    "index.lakehouse.type": "glue",
    "index.lakehouse.region": "us-west-2",
    "index.lakehouse.warehouse": "s3://my-bucket/warehouse",
    "index.lakehouse.namespace": "my_database",
    "index.lakehouse.table": "my_table",
    "index.lakehouse.auth_type": "keys",
    "index.lakehouse.credential_key": "my_aws_creds"
  }
}
```
```bash
opensearch-keystore add lakehouse.credentials.my_aws_creds.access_key
opensearch-keystore add lakehouse.credentials.my_aws_creds.secret_key
```

### Security integration

Since Iceberg tables are native OpenSearch indices, security works out of the box:
```json
PUT _plugins/_security/api/roles/iceberg_reader
{
  "index_permissions": [{
    "index_patterns": ["my_iceberg_table"],
    "allowed_actions": ["read"]
  }]
}
```

## Test plan

- [x] `./gradlew :sandbox:plugins:lakehouse-iceberg:assemble` — compile, spotless, javadoc, jarHell
- [x] `./gradlew :sandbox:plugins:lakehouse-iceberg:test` — unit tests pass