### PR TITLE
feat(lakehouse): Iceberg catalog connector and Calcite schema integration

### DIFF
--- a/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/schema/SchemaContributor.java
+++ b/sandbox/libs/analytics-framework/src/main/java/org/opensearch/analytics/schema/SchemaContributor.java
@@ -9,6 +9,7 @@
 package org.opensearch.analytics.schema;
 
 import org.apache.calcite.schema.SchemaPlus;
+import org.opensearch.cluster.metadata.IndexMetadata;
 
 /**
  * SPI for plugins that contribute additional tables to the Calcite schema.
@@ -19,10 +20,13 @@ import org.apache.calcite.schema.SchemaPlus;
  * source plugins (e.g., Iceberg, Delta Lake) to register their tables into
  * the Calcite schema without creating compile-time dependencies from the
  * analytics engine to those plugins.
+ * <p>
+ * Implementations may also override {@link #claims(IndexMetadata)} to indicate
+ * that certain OpenSearch indices are owned by the contributor and should be
+ * skipped by the default schema builder.
  *
  * @opensearch.internal
  */
-@FunctionalInterface
 public interface SchemaContributor {
 
     /**
@@ -33,4 +37,16 @@ public interface SchemaContributor {
      *                     server dependency in the library)
      */
     void contributeSchema(SchemaPlus schema, Object clusterState);
+
+    /**
+     * Returns true if this contributor owns the given index and will handle
+     * its schema registration. Indices claimed by any contributor are skipped
+     * by {@code OpenSearchSchemaBuilder}.
+     *
+     * @param indexMetadata the index metadata to check
+     * @return true if this contributor handles this index
+     */
+    default boolean claims(IndexMetadata indexMetadata) {
+        return false;
+    }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/AnalyticsPlugin.java
@@ -17,7 +17,10 @@ import org.apache.logging.log4j.Logger;
 import org.opensearch.analytics.exec.DefaultPlanExecutor;
 import org.opensearch.analytics.exec.QueryPlanExecutor;
 import org.opensearch.analytics.schema.OpenSearchSchemaBuilder;
+import org.opensearch.analytics.schema.SchemaContributor;
 import org.opensearch.analytics.spi.AnalyticsSearchBackendPlugin;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.IndexNameExpressionResolver;
 import org.opensearch.cluster.service.ClusterService;
 import org.opensearch.common.inject.Module;
@@ -36,7 +39,9 @@ import org.opensearch.watcher.ResourceWatcherService;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 
 /**
@@ -55,12 +60,14 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin {
     public AnalyticsPlugin() {}
 
     private final List<AnalyticsSearchBackendPlugin> backEnds = new ArrayList<>();
+    private final List<SchemaContributor> schemaContributors = new ArrayList<>();
     private SqlOperatorTable operatorTable;
 
     @SuppressWarnings("rawtypes")
     @Override
     public void loadExtensions(ExtensionLoader loader) {
         backEnds.addAll(loader.loadExtensions(AnalyticsSearchBackendPlugin.class));
+        schemaContributors.addAll(loader.loadExtensions(SchemaContributor.class));
         operatorTable = aggregateOperatorTables();
     }
 
@@ -80,7 +87,7 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin {
     ) {
         return List.of(
             new DefaultPlanExecutor(backEnds, null/* TODO: pass indices service */, clusterService),
-            new DefaultEngineContext(clusterService, operatorTable)
+            new DefaultEngineContext(clusterService, operatorTable, schemaContributors)
         );
     }
 
@@ -102,11 +109,25 @@ public class AnalyticsPlugin extends Plugin implements ExtensiblePlugin {
     /**
      * Default implementation of {@link EngineContext}.
      */
-    static record DefaultEngineContext(ClusterService clusterService, SqlOperatorTable operatorTable) implements EngineContext {
+    static record DefaultEngineContext(ClusterService clusterService, SqlOperatorTable operatorTable, List<
+        SchemaContributor> schemaContributors) implements EngineContext {
 
         @Override
         public SchemaPlus getSchema() {
-            return OpenSearchSchemaBuilder.buildSchema(clusterService.state());
+            ClusterState state = clusterService.state();
+            Set<String> claimedIndices = new HashSet<>();
+            for (SchemaContributor c : schemaContributors) {
+                for (IndexMetadata idx : state.metadata().indices().values()) {
+                    if (c.claims(idx)) {
+                        claimedIndices.add(idx.getIndex().getName());
+                    }
+                }
+            }
+            SchemaPlus schema = OpenSearchSchemaBuilder.buildSchema(state, claimedIndices);
+            for (SchemaContributor c : schemaContributors) {
+                c.contributeSchema(schema, state);
+            }
+            return schema;
         }
     }
 }

--- a/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
+++ b/sandbox/plugins/analytics-engine/src/main/java/org/opensearch/analytics/schema/OpenSearchSchemaBuilder.java
@@ -19,6 +19,7 @@ import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.cluster.metadata.MappingMetadata;
 
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Builds a Calcite {@link SchemaPlus} from OpenSearch {@link ClusterState} index mappings.
@@ -38,11 +39,25 @@ public class OpenSearchSchemaBuilder {
      * @param clusterState the current cluster state to derive schema from
      */
     public static SchemaPlus buildSchema(ClusterState clusterState) {
+        return buildSchema(clusterState, Set.of());
+    }
+
+    /**
+     * Builds a Calcite SchemaPlus from the given ClusterState, skipping
+     * indices claimed by {@link SchemaContributor} plugins.
+     *
+     * @param clusterState  the current cluster state to derive schema from
+     * @param skipIndices   index names to skip (handled by SchemaContributors)
+     */
+    public static SchemaPlus buildSchema(ClusterState clusterState, Set<String> skipIndices) {
         CalciteSchema rootSchema = CalciteSchema.createRootSchema(true);
         SchemaPlus schemaPlus = rootSchema.plus();
 
         for (Map.Entry<String, IndexMetadata> entry : clusterState.metadata().indices().entrySet()) {
             String indexName = entry.getKey();
+            if (skipIndices.contains(indexName)) {
+                continue;
+            }
             IndexMetadata indexMetadata = entry.getValue();
             MappingMetadata mapping = indexMetadata.mapping();
             if (mapping == null) {

--- a/sandbox/plugins/lakehouse-iceberg/build.gradle
+++ b/sandbox/plugins/lakehouse-iceberg/build.gradle
@@ -20,4 +20,89 @@ dependencies {
     // Analytics engine and framework (compile-only, provided at runtime by analytics-engine plugin)
     compileOnly project(':sandbox:plugins:analytics-engine')
     compileOnly project(':sandbox:libs:analytics-framework')
+
+    // Iceberg SDK
+    implementation "org.apache.iceberg:iceberg-api:1.7.1"
+    implementation "org.apache.iceberg:iceberg-core:1.7.1"
+    implementation "org.apache.iceberg:iceberg-aws:1.7.1"
+    implementation "org.apache.iceberg:iceberg-bundled-guava:1.7.1"
+
+    // Hadoop client (api + runtime cover hadoop-common, hadoop-auth, shaded deps)
+    implementation "org.apache.hadoop:hadoop-client-api:3.4.2"
+    runtimeOnly "org.apache.hadoop:hadoop-client-runtime:3.4.2"
+
+    // Iceberg transitive dependencies (OpenSearch plugin system strips transitives)
+    runtimeOnly "org.apache.iceberg:iceberg-common:1.7.1"
+    runtimeOnly "io.airlift:aircompressor:0.27"
+    runtimeOnly "com.github.ben-manes.caffeine:caffeine:2.9.3"
+    runtimeOnly "dev.failsafe:failsafe:3.3.2"
+    runtimeOnly "org.roaringbitmap:RoaringBitmap:1.3.0"
+
+    // AWS SDK
+    implementation "software.amazon.awssdk:glue:${versions.aws}"
+    implementation "software.amazon.awssdk:s3:${versions.aws}"
+    implementation "software.amazon.awssdk:sts:${versions.aws}"
+    implementation "software.amazon.awssdk:auth:${versions.aws}"
+    implementation "software.amazon.awssdk:regions:${versions.aws}"
+    implementation "software.amazon.awssdk:identity-spi:${versions.aws}"
+    implementation "software.amazon.awssdk:utils:${versions.aws}"
+    implementation "software.amazon.awssdk:aws-core:${versions.aws}"
+    implementation "software.amazon.awssdk:sdk-core:${versions.aws}"
+
+    // AWS SDK transitive deps (OpenSearch plugin system strips transitives)
+    runtimeOnly "software.amazon.awssdk:http-client-spi:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:url-connection-client:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:apache-client:${versions.aws}"
+    runtimeOnly "org.apache.httpcomponents:httpclient:4.5.14"
+    runtimeOnly "org.apache.httpcomponents:httpcore:4.4.16"
+    runtimeOnly "commons-logging:commons-logging:1.2"
+    runtimeOnly "software.amazon.awssdk:profiles:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:endpoints-spi:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:protocol-core:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:json-utils:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:aws-json-protocol:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:aws-query-protocol:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:aws-xml-protocol:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:third-party-jackson-core:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:metrics-spi:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:annotations:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:checksums:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:checksums-spi:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:retries:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:retries-spi:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:http-auth-spi:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:http-auth:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:http-auth-aws:${versions.aws}"
+    runtimeOnly "software.amazon.awssdk:crt-core:${versions.aws}"
+}
+
+// JaCoCo coverage enforcement — fail build if line coverage drops below threshold
+jacocoTestCoverageVerification {
+    violationRules {
+        rule {
+            element = 'CLASS'
+            // IcebergCatalogConnector needs live AWS credentials to test
+            excludes = [
+                'org.opensearch.lakehouse.catalog.IcebergCatalogConnector'
+            ]
+            limit {
+                counter = 'LINE'
+                minimum = 0.70
+            }
+        }
+    }
+}
+check.dependsOn jacocoTestCoverageVerification
+
+configurations.all {
+    resolutionStrategy {
+        force "com.google.guava:guava:33.4.0-jre"
+        force "com.google.guava:failureaccess:1.0.2"
+        force "com.fasterxml.jackson.core:jackson-core:${versions.jackson}"
+        force "com.fasterxml.jackson.core:jackson-databind:${versions.jackson_databind}"
+        force "com.fasterxml.jackson.core:jackson-annotations:${versions.jackson_annotations}"
+        force "org.slf4j:slf4j-api:${versions.slf4j}"
+        force "commons-logging:commons-logging:1.3.5"
+        force "commons-codec:commons-codec:1.15"
+    }
 }

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/LakehousePlugin.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/LakehousePlugin.java
@@ -14,7 +14,11 @@ import org.opensearch.analytics.exec.ExternalScanContext;
 import org.opensearch.analytics.exec.ExternalTableExecutor;
 import org.opensearch.analytics.schema.ExternalTable;
 import org.opensearch.analytics.schema.SchemaContributor;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
 import org.opensearch.common.settings.Setting;
+import org.opensearch.lakehouse.catalog.IcebergCatalogConnector;
+import org.opensearch.lakehouse.schema.IcebergSchemaContributor;
 import org.opensearch.plugins.Plugin;
 
 import java.util.List;
@@ -37,6 +41,14 @@ import java.util.List;
  */
 public class LakehousePlugin extends Plugin implements SchemaContributor, ExternalTableExecutor {
 
+    /**
+     * Shared catalog connector — static because SPI creates separate instances
+     * for SchemaContributor and ExternalTableExecutor interfaces.
+     */
+    private static final IcebergCatalogConnector catalogConnector = new IcebergCatalogConnector();
+
+    private static final IcebergSchemaContributor schemaContributor = new IcebergSchemaContributor(catalogConnector);
+
     /** Creates a new LakehousePlugin instance. */
     public LakehousePlugin() {}
 
@@ -46,18 +58,28 @@ public class LakehousePlugin extends Plugin implements SchemaContributor, Extern
     }
 
     @Override
+    public boolean claims(IndexMetadata indexMetadata) {
+        return schemaContributor.claims(indexMetadata);
+    }
+
+    @Override
     public boolean supports(ExternalTable externalTable) {
         return "iceberg".equals(externalTable.format());
     }
 
     @Override
     public void contributeSchema(SchemaPlus schema, Object clusterState) {
-        // Will be implemented in a later PR (Iceberg catalog connector + schema discovery)
+        schemaContributor.contributeSchema(schema, (ClusterState) clusterState);
     }
 
     @Override
     public ExternalScanContext prepareScan(RelNode logicalPlan, ExternalTable externalTable) {
         // Will be implemented in a later PR (scan planning)
         throw new UnsupportedOperationException("Iceberg scan planning not yet implemented");
+    }
+
+    /** Returns the shared catalog connector (for use by ExternalTableExecutor in later PRs). */
+    static IcebergCatalogConnector getCatalogConnector() {
+        return catalogConnector;
     }
 }

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/catalog/AwsCredentials.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/catalog/AwsCredentials.java
@@ -1,0 +1,76 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.catalog;
+
+/**
+ * Holds resolved AWS credentials for a specific catalog.
+ * Immutable — a new instance is created on each refresh.
+ */
+public final class AwsCredentials {
+    private final String accessKeyId;
+    private final String secretAccessKey;
+    private final String sessionToken;
+    private final long expiryTimestamp;
+
+    /**
+     * Creates a new AWS credentials holder with expiry.
+     *
+     * @param accessKeyId     AWS access key ID
+     * @param secretAccessKey AWS secret access key
+     * @param sessionToken    AWS session token, or null for long-lived credentials
+     * @param expiryTimestamp epoch millis when these credentials expire, or 0 for never
+     */
+    public AwsCredentials(String accessKeyId, String secretAccessKey, String sessionToken, long expiryTimestamp) {
+        this.accessKeyId = accessKeyId;
+        this.secretAccessKey = secretAccessKey;
+        this.sessionToken = sessionToken;
+        this.expiryTimestamp = expiryTimestamp;
+    }
+
+    /**
+     * Creates a new AWS credentials holder that never expires.
+     *
+     * @param accessKeyId     AWS access key ID
+     * @param secretAccessKey AWS secret access key
+     * @param sessionToken    AWS session token, or null for long-lived credentials
+     */
+    public AwsCredentials(String accessKeyId, String secretAccessKey, String sessionToken) {
+        this(accessKeyId, secretAccessKey, sessionToken, 0);
+    }
+
+    /** Returns the AWS access key ID. */
+    public String getAccessKeyId() {
+        return accessKeyId;
+    }
+
+    /** Returns the AWS secret access key. */
+    public String getSecretAccessKey() {
+        return secretAccessKey;
+    }
+
+    /** Returns the AWS session token, or null if not present. */
+    public String getSessionToken() {
+        return sessionToken;
+    }
+
+    /** Returns the expiry timestamp in epoch millis, or 0 if never expires. */
+    public long getExpiryTimestamp() {
+        return expiryTimestamp;
+    }
+
+    /** Returns true if both access key and secret key are present and non-empty. */
+    public boolean isComplete() {
+        return accessKeyId != null && !accessKeyId.isEmpty() && secretAccessKey != null && !secretAccessKey.isEmpty();
+    }
+
+    /** Returns true if these credentials have an expiry and that expiry has passed. */
+    public boolean isExpired() {
+        return expiryTimestamp > 0 && System.currentTimeMillis() > expiryTimestamp;
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/catalog/CatalogConfig.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/catalog/CatalogConfig.java
@@ -1,0 +1,153 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.catalog;
+
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.lakehouse.LakehouseSettings;
+
+import java.util.Objects;
+
+/**
+ * Immutable configuration for an Iceberg catalog connection,
+ * built from OpenSearch index settings.
+ */
+public final class CatalogConfig {
+
+    private final String indexName;
+    private final CatalogType catalogType;
+    private final String region;
+    private final String warehouse;
+    private final String namespace;
+    private final String tableName;
+    private final String authType;
+    private final String roleArn;
+    private final String credentialKey;
+
+    /**
+     * Creates a catalog configuration.
+     *
+     * @param indexName     the OpenSearch index name
+     * @param catalogType   type of catalog backend
+     * @param region        AWS region
+     * @param warehouse     warehouse location (s3:// or file://)
+     * @param namespace     Iceberg namespace
+     * @param tableName     Iceberg table name
+     * @param authType      authentication type: role, keys, or default
+     * @param roleArn       IAM role ARN (for auth_type=role)
+     * @param credentialKey keystore credential name (for auth_type=keys)
+     */
+    public CatalogConfig(
+        String indexName,
+        CatalogType catalogType,
+        String region,
+        String warehouse,
+        String namespace,
+        String tableName,
+        String authType,
+        String roleArn,
+        String credentialKey
+    ) {
+        this.indexName = Objects.requireNonNull(indexName, "indexName must not be null");
+        this.catalogType = Objects.requireNonNull(catalogType, "catalogType must not be null");
+        this.warehouse = Objects.requireNonNull(warehouse, "warehouse must not be null");
+        this.namespace = Objects.requireNonNull(namespace, "namespace must not be null");
+        this.tableName = Objects.requireNonNull(tableName, "tableName must not be null");
+        this.region = region;
+        this.authType = (authType != null && !authType.isEmpty()) ? authType : "default";
+        this.roleArn = roleArn;
+        this.credentialKey = credentialKey;
+    }
+
+    /**
+     * Builds a CatalogConfig from an OpenSearch index's settings.
+     *
+     * @param indexMetadata the index metadata containing lakehouse settings
+     * @return a new CatalogConfig
+     * @throws IllegalArgumentException if required settings are missing
+     */
+    public static CatalogConfig fromIndexSettings(IndexMetadata indexMetadata) {
+        Settings settings = indexMetadata.getSettings();
+        String indexName = indexMetadata.getIndex().getName();
+
+        String typeStr = LakehouseSettings.INDEX_LAKEHOUSE_TYPE.get(settings);
+        if (typeStr == null || typeStr.isEmpty()) {
+            throw new IllegalArgumentException("index.lakehouse.type is required for index [" + indexName + "]");
+        }
+        String warehouse = LakehouseSettings.INDEX_LAKEHOUSE_WAREHOUSE.get(settings);
+        if (warehouse == null || warehouse.isEmpty()) {
+            throw new IllegalArgumentException("index.lakehouse.warehouse is required for index [" + indexName + "]");
+        }
+        String namespace = LakehouseSettings.INDEX_LAKEHOUSE_NAMESPACE.get(settings);
+        if (namespace == null || namespace.isEmpty()) {
+            throw new IllegalArgumentException("index.lakehouse.namespace is required for index [" + indexName + "]");
+        }
+        String table = LakehouseSettings.INDEX_LAKEHOUSE_TABLE.get(settings);
+        if (table == null || table.isEmpty()) {
+            throw new IllegalArgumentException("index.lakehouse.table is required for index [" + indexName + "]");
+        }
+
+        return new CatalogConfig(
+            indexName,
+            CatalogType.fromString(typeStr),
+            LakehouseSettings.INDEX_LAKEHOUSE_REGION.get(settings),
+            warehouse,
+            namespace,
+            table,
+            LakehouseSettings.INDEX_LAKEHOUSE_AUTH_TYPE.get(settings),
+            LakehouseSettings.INDEX_LAKEHOUSE_ROLE_ARN.get(settings),
+            LakehouseSettings.INDEX_LAKEHOUSE_CREDENTIAL_KEY.get(settings)
+        );
+    }
+
+    /** Returns the OpenSearch index name. */
+    public String indexName() {
+        return indexName;
+    }
+
+    /** Returns the catalog backend type. */
+    public CatalogType catalogType() {
+        return catalogType;
+    }
+
+    /** Returns the AWS region, or null. */
+    public String region() {
+        return region;
+    }
+
+    /** Returns the warehouse location. */
+    public String warehouse() {
+        return warehouse;
+    }
+
+    /** Returns the Iceberg namespace. */
+    public String namespace() {
+        return namespace;
+    }
+
+    /** Returns the Iceberg table name. */
+    public String tableName() {
+        return tableName;
+    }
+
+    /** Returns the authentication type. */
+    public String authType() {
+        return authType;
+    }
+
+    /** Returns the IAM role ARN, or null. */
+    public String roleArn() {
+        return roleArn;
+    }
+
+    /** Returns the keystore credential key, or null. */
+    public String credentialKey() {
+        return credentialKey;
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/catalog/CatalogType.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/catalog/CatalogType.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.catalog;
+
+import java.util.Locale;
+
+/**
+ * Supported Iceberg catalog types.
+ */
+public enum CatalogType {
+    /** AWS Glue Data Catalog. */
+    GLUE,
+    /** Local Hadoop-based catalog (for testing). */
+    HADOOP,
+    /** Iceberg REST Catalog. */
+    REST;
+
+    /**
+     * Parses a catalog type string (case-insensitive).
+     *
+     * @param value the string to parse
+     * @return the matching CatalogType
+     * @throws IllegalArgumentException if the value is not a valid catalog type
+     */
+    public static CatalogType fromString(String value) {
+        return valueOf(value.toUpperCase(Locale.ROOT));
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/catalog/IcebergCatalogConnector.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/catalog/IcebergCatalogConnector.java
@@ -1,0 +1,225 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.catalog;
+
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.auth.credentials.DefaultCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.sts.StsClient;
+import software.amazon.awssdk.services.sts.model.AssumeRoleRequest;
+import software.amazon.awssdk.services.sts.model.AssumeRoleResponse;
+import software.amazon.awssdk.services.sts.model.Credentials;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.CatalogProperties;
+import org.apache.iceberg.CatalogUtil;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.catalog.Catalog;
+import org.apache.iceberg.catalog.TableIdentifier;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Manages Iceberg catalog connections and loads table metadata.
+ * One catalog instance per index (simple approach — deduplication deferred).
+ */
+public class IcebergCatalogConnector {
+
+    private static final Logger logger = LogManager.getLogger(IcebergCatalogConnector.class);
+
+    /** Assumed lifetime for STS session credentials. */
+    private static final long STS_CREDENTIAL_LIFETIME_MS = 10 * 60 * 1000L;
+
+    /** Buffer before actual expiry to trigger early refresh. */
+    private static final long REFRESH_BUFFER_MS = 10_000L;
+
+    private final ConcurrentHashMap<String, Catalog> catalogs = new ConcurrentHashMap<>();
+    private final ConcurrentHashMap<String, AwsCredentials> credentials = new ConcurrentHashMap<>();
+
+    /** Creates a new catalog connector. */
+    public IcebergCatalogConnector() {}
+
+    /**
+     * Loads an Iceberg table using the given catalog config. Creates and caches
+     * the underlying Iceberg Catalog if not already present.
+     *
+     * @param config the catalog configuration built from index settings
+     * @return the loaded Iceberg {@link Table}
+     */
+    @SuppressWarnings("removal")
+    public Table loadTable(CatalogConfig config) {
+        String catalogKey = config.indexName();
+        Catalog catalog = catalogs.computeIfAbsent(catalogKey, k -> buildCatalog(config));
+
+        TableIdentifier tableId = TableIdentifier.of(config.namespace(), config.tableName());
+        logger.info("[CatalogConnector] Loading table [{}] for index [{}]", tableId, config.indexName());
+
+        ClassLoader prev = Thread.currentThread().getContextClassLoader();
+        try {
+            setCredentialsOnThread(config);
+            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+            Table table = AccessController.doPrivileged((PrivilegedAction<Table>) () -> catalog.loadTable(tableId));
+            logger.info(
+                "[CatalogConnector] Loaded table [{}]: location=[{}], snapshot=[{}]",
+                tableId,
+                table.location(),
+                table.currentSnapshot() != null ? table.currentSnapshot().snapshotId() : "none"
+            );
+            return table;
+        } finally {
+            LakehouseCredentialsProvider.clear();
+            Thread.currentThread().setContextClassLoader(prev);
+        }
+    }
+
+    /**
+     * Returns cached credentials for a config, resolving fresh ones if expired.
+     *
+     * @param config the catalog configuration
+     * @return resolved credentials, or null
+     */
+    public AwsCredentials getCredentials(CatalogConfig config) {
+        return getFreshCredentials(config);
+    }
+
+    @SuppressWarnings("removal")
+    private Catalog buildCatalog(CatalogConfig config) {
+        logger.info(
+            "[CatalogConnector] Building catalog for index [{}] type=[{}] region=[{}] warehouse=[{}]",
+            config.indexName(),
+            config.catalogType(),
+            config.region(),
+            config.warehouse()
+        );
+
+        AwsCredentials creds = resolveCredentials(config);
+        if (creds != null && creds.isComplete()) {
+            credentials.put(config.indexName(), creds);
+        }
+
+        Map<String, String> properties = buildCatalogProperties(config);
+
+        ClassLoader prev = Thread.currentThread().getContextClassLoader();
+        try {
+            setCredentialsOnThread(config);
+            Thread.currentThread().setContextClassLoader(getClass().getClassLoader());
+            return AccessController.doPrivileged(
+                (PrivilegedAction<Catalog>) () -> CatalogUtil.buildIcebergCatalog(config.indexName(), properties, new Configuration())
+            );
+        } finally {
+            LakehouseCredentialsProvider.clear();
+            Thread.currentThread().setContextClassLoader(prev);
+        }
+    }
+
+    private void setCredentialsOnThread(CatalogConfig config) {
+        AwsCredentials creds = getFreshCredentials(config);
+        if (creds != null && creds.isComplete()) {
+            LakehouseCredentialsProvider.set(creds);
+        }
+    }
+
+    private AwsCredentials getFreshCredentials(CatalogConfig config) {
+        String key = config.indexName();
+        AwsCredentials creds = credentials.get(key);
+        if (creds != null && !creds.isExpired()) {
+            return creds;
+        }
+        // ConcurrentHashMap.compute() locks per-bucket, so only the same index
+        // blocks — unrelated indices can refresh concurrently.
+        return credentials.compute(key, (k, existing) -> {
+            if (existing != null && !existing.isExpired()) {
+                return existing;
+            }
+            AwsCredentials fresh = resolveCredentials(config);
+            if (fresh != null && fresh.isComplete()) {
+                logger.info("[CatalogConnector] Refreshed credentials for index [{}]", key);
+                return fresh;
+            }
+            return existing;
+        });
+    }
+
+    @SuppressWarnings("removal")
+    private AwsCredentials resolveCredentials(CatalogConfig config) {
+        String authType = config.authType();
+        return AccessController.doPrivileged((PrivilegedAction<AwsCredentials>) () -> {
+            try {
+                if ("role".equals(authType)) {
+                    return resolveRoleCredentials(config);
+                } else if ("keys".equals(authType)) {
+                    return resolveKeystoreCredentials(config);
+                } else {
+                    return resolveDefaultCredentials();
+                }
+            } catch (Exception e) {
+                logger.warn("[CatalogConnector] Credential resolution failed for index [{}]: {}", config.indexName(), e.getMessage());
+                return null;
+            }
+        });
+    }
+
+    private AwsCredentials resolveRoleCredentials(CatalogConfig config) {
+        String roleArn = config.roleArn();
+        if (roleArn == null || roleArn.isEmpty()) {
+            throw new IllegalArgumentException("role_arn is required when auth_type=role for index [" + config.indexName() + "]");
+        }
+        StsClient stsClient = StsClient.builder().region(config.region() != null ? Region.of(config.region()) : Region.US_EAST_1).build();
+        try {
+            AssumeRoleResponse response = stsClient.assumeRole(
+                AssumeRoleRequest.builder().roleArn(roleArn).roleSessionName("lakehouse-" + config.indexName()).build()
+            );
+            Credentials stsCreds = response.credentials();
+            long expiry = stsCreds.expiration().toEpochMilli() - REFRESH_BUFFER_MS;
+            return new AwsCredentials(stsCreds.accessKeyId(), stsCreds.secretAccessKey(), stsCreds.sessionToken(), expiry);
+        } finally {
+            stsClient.close();
+        }
+    }
+
+    private AwsCredentials resolveKeystoreCredentials(CatalogConfig config) {
+        // Keystore credentials are resolved at query time by the plugin
+        // via Settings. For now, fall back to default credentials chain.
+        // Full keystore integration comes when contributeSchema passes Settings.
+        logger.info("[CatalogConnector] auth_type=keys for index [{}] — keystore integration pending", config.indexName());
+        return resolveDefaultCredentials();
+    }
+
+    private AwsCredentials resolveDefaultCredentials() {
+        software.amazon.awssdk.auth.credentials.AwsCredentials sdkCreds = DefaultCredentialsProvider.create().resolveCredentials();
+        String sessionToken = null;
+        long expiryTimestamp = 0;
+        if (sdkCreds instanceof AwsSessionCredentials) {
+            sessionToken = ((AwsSessionCredentials) sdkCreds).sessionToken();
+            expiryTimestamp = System.currentTimeMillis() + STS_CREDENTIAL_LIFETIME_MS - REFRESH_BUFFER_MS;
+        }
+        return new AwsCredentials(sdkCreds.accessKeyId(), sdkCreds.secretAccessKey(), sessionToken, expiryTimestamp);
+    }
+
+    private Map<String, String> buildCatalogProperties(CatalogConfig config) {
+        Map<String, String> props = new HashMap<>();
+        props.put(CatalogProperties.WAREHOUSE_LOCATION, config.warehouse());
+        props.put(CatalogUtil.ICEBERG_CATALOG_TYPE, config.catalogType().name().toLowerCase(Locale.ROOT));
+
+        if (config.region() != null) {
+            props.put("client.region", config.region());
+        }
+
+        props.put("client.credentials-provider", "org.opensearch.lakehouse.catalog.LakehouseCredentialsProvider");
+
+        return props;
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/catalog/LakehouseCredentialsProvider.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/catalog/LakehouseCredentialsProvider.java
@@ -1,0 +1,92 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.catalog;
+
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.auth.credentials.AwsSessionCredentials;
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+import java.util.Map;
+
+/**
+ * A ThreadLocal-based {@link AwsCredentialsProvider} for the Iceberg SDK.
+ *
+ * <p>The Iceberg SDK instantiates this class by name via reflection (from the
+ * {@code client.credentials-provider} catalog property). It calls
+ * {@link #resolveCredentials()} each time it needs credentials for an AWS API call.
+ *
+ * <p>Calling code sets per-catalog credentials on the current thread's ThreadLocal
+ * before making Iceberg SDK calls, and clears them in a finally block.
+ */
+public class LakehouseCredentialsProvider implements AwsCredentialsProvider {
+
+    private static final ThreadLocal<AwsCredentials> CURRENT = new ThreadLocal<>();
+
+    /** No-arg constructor. */
+    public LakehouseCredentialsProvider() {}
+
+    /**
+     * Static factory method required by Iceberg SDK's {@code AwsClientProperties}.
+     *
+     * @param properties catalog properties (unused — credentials come from ThreadLocal)
+     * @return a new provider instance
+     */
+    public static LakehouseCredentialsProvider create(Map<String, String> properties) {
+        return new LakehouseCredentialsProvider();
+    }
+
+    /**
+     * No-arg static factory fallback for Iceberg SDK.
+     *
+     * @return a new provider instance
+     */
+    public static LakehouseCredentialsProvider create() {
+        return new LakehouseCredentialsProvider();
+    }
+
+    /**
+     * Sets credentials on the current thread. Must be paired with {@link #clear()} in a finally block.
+     *
+     * @param creds the per-catalog credentials
+     */
+    public static void set(AwsCredentials creds) {
+        CURRENT.set(creds);
+    }
+
+    /**
+     * Returns the credentials on the current thread, or null if none set.
+     *
+     * @return current thread credentials, or null
+     */
+    public static AwsCredentials get() {
+        return CURRENT.get();
+    }
+
+    /**
+     * Clears the current thread's credentials. Always call in a finally block.
+     */
+    public static void clear() {
+        CURRENT.remove();
+    }
+
+    @Override
+    public software.amazon.awssdk.auth.credentials.AwsCredentials resolveCredentials() {
+        AwsCredentials creds = CURRENT.get();
+        if (creds == null || !creds.isComplete()) {
+            throw SdkClientException.create(
+                "No credentials set on current thread. " + "Call LakehouseCredentialsProvider.set() before making Iceberg SDK calls."
+            );
+        }
+        if (creds.getSessionToken() != null) {
+            return AwsSessionCredentials.create(creds.getAccessKeyId(), creds.getSecretAccessKey(), creds.getSessionToken());
+        }
+        return AwsBasicCredentials.create(creds.getAccessKeyId(), creds.getSecretAccessKey());
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/catalog/package-info.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/catalog/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Iceberg catalog connectivity: catalog types, configuration, AWS credential resolution,
+ * and catalog connector for loading Iceberg table metadata.
+ */
+package org.opensearch.lakehouse.catalog;

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/schema/IcebergCalciteTable.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/schema/IcebergCalciteTable.java
@@ -1,0 +1,104 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.schema;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.schema.impl.AbstractTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Types;
+import org.opensearch.analytics.schema.ExternalTable;
+import org.opensearch.lakehouse.catalog.CatalogConfig;
+import org.opensearch.lakehouse.catalog.IcebergCatalogConnector;
+
+/**
+ * Calcite table backed by an Iceberg table.
+ * <p>
+ * Registered into the Calcite schema lazily — the expensive Iceberg SDK call
+ * ({@code loadTable()}) is deferred until Calcite actually calls
+ * {@link #getRowType(RelDataTypeFactory)}, which only happens for tables
+ * referenced by the query. This avoids loading metadata for every lakehouse
+ * index on every query.
+ */
+public class IcebergCalciteTable extends AbstractTable implements ExternalTable {
+
+    private final CatalogConfig config;
+    private final IcebergCatalogConnector catalogConnector;
+
+    private volatile Schema icebergSchema;
+    private volatile long snapshotId = -1L;
+
+    /**
+     * Creates a lazy IcebergCalciteTable. No Iceberg SDK calls are made until
+     * {@link #getRowType(RelDataTypeFactory)} is called.
+     *
+     * @param config           the catalog configuration for this table
+     * @param catalogConnector the connector used to load the table on demand
+     */
+    public IcebergCalciteTable(CatalogConfig config, IcebergCatalogConnector catalogConnector) {
+        this.config = config;
+        this.catalogConnector = catalogConnector;
+    }
+
+    @Override
+    public RelDataType getRowType(RelDataTypeFactory typeFactory) {
+        ensureLoaded();
+        RelDataTypeFactory.Builder builder = typeFactory.builder();
+        for (Types.NestedField field : icebergSchema.columns()) {
+            SqlTypeName sqlType = IcebergTypeMapper.toSqlTypeName(field.type());
+            RelDataType type;
+            if (sqlType == SqlTypeName.DECIMAL) {
+                Types.DecimalType decimal = (Types.DecimalType) field.type();
+                type = typeFactory.createSqlType(sqlType, decimal.precision(), decimal.scale());
+            } else {
+                type = typeFactory.createSqlType(sqlType);
+            }
+            builder.add(field.name(), typeFactory.createTypeWithNullability(type, field.isOptional()));
+        }
+        return builder.build();
+    }
+
+    private void ensureLoaded() {
+        if (icebergSchema != null) {
+            return;
+        }
+        synchronized (this) {
+            if (icebergSchema != null) {
+                return;
+            }
+            Table table = catalogConnector.loadTable(config);
+            this.icebergSchema = table.schema();
+            Snapshot current = table.currentSnapshot();
+            this.snapshotId = current != null ? current.snapshotId() : -1L;
+        }
+    }
+
+    @Override
+    public String qualifiedName() {
+        return config.namespace() + "." + config.tableName();
+    }
+
+    @Override
+    public String format() {
+        return "iceberg";
+    }
+
+    /** Returns the pinned snapshot ID, or -1 if not yet loaded or table has no snapshots. */
+    public long snapshotId() {
+        return snapshotId;
+    }
+
+    /** Returns the catalog configuration for this table. */
+    public CatalogConfig catalogConfig() {
+        return config;
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/schema/IcebergSchemaContributor.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/schema/IcebergSchemaContributor.java
@@ -1,0 +1,77 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.schema;
+
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.lakehouse.LakehouseSettings;
+import org.opensearch.lakehouse.catalog.CatalogConfig;
+import org.opensearch.lakehouse.catalog.IcebergCatalogConnector;
+
+/**
+ * Contributes Iceberg tables to the Calcite schema.
+ * <p>
+ * For each OpenSearch index with {@code index.lakehouse.enabled=true},
+ * registers a lazy {@link IcebergCalciteTable} into the Calcite schema.
+ * The expensive Iceberg SDK call ({@code loadTable()}) is deferred until
+ * Calcite actually resolves the table during query parsing — so only
+ * tables referenced by the query pay the cost.
+ */
+public class IcebergSchemaContributor {
+
+    private static final Logger logger = LogManager.getLogger(IcebergSchemaContributor.class);
+
+    private final IcebergCatalogConnector catalogConnector;
+
+    /**
+     * Creates a contributor with the given catalog connector.
+     *
+     * @param catalogConnector the shared catalog connector
+     */
+    public IcebergSchemaContributor(IcebergCatalogConnector catalogConnector) {
+        this.catalogConnector = catalogConnector;
+    }
+
+    /**
+     * Returns true if the index is a lakehouse index ({@code index.lakehouse.enabled=true}).
+     *
+     * @param indexMetadata the index metadata to check
+     * @return true if this is a lakehouse index
+     */
+    public boolean claims(IndexMetadata indexMetadata) {
+        return LakehouseSettings.INDEX_LAKEHOUSE_ENABLED.get(indexMetadata.getSettings());
+    }
+
+    /**
+     * Registers lazy Iceberg table placeholders for all lakehouse indices.
+     * No Iceberg SDK calls are made here — metadata is loaded on demand
+     * when Calcite resolves a table referenced by a query.
+     *
+     * @param schema       the mutable Calcite schema
+     * @param clusterState the current cluster state
+     */
+    public void contributeSchema(SchemaPlus schema, ClusterState clusterState) {
+        for (IndexMetadata indexMetadata : clusterState.metadata().indices().values()) {
+            if (!claims(indexMetadata)) {
+                continue;
+            }
+            String indexName = indexMetadata.getIndex().getName();
+            try {
+                CatalogConfig config = CatalogConfig.fromIndexSettings(indexMetadata);
+                schema.add(indexName, new IcebergCalciteTable(config, catalogConnector));
+                logger.debug("[SchemaContributor] Registered lazy Iceberg table for index [{}]", indexName);
+            } catch (Exception e) {
+                logger.warn("[SchemaContributor] Failed to register Iceberg table for index [{}]: {}", indexName, e.getMessage());
+            }
+        }
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/schema/IcebergTypeMapper.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/schema/IcebergTypeMapper.java
@@ -1,0 +1,58 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.schema;
+
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.iceberg.types.Type;
+
+/**
+ * Maps Iceberg {@link Type} to Calcite {@link SqlTypeName}.
+ */
+public final class IcebergTypeMapper {
+
+    private IcebergTypeMapper() {}
+
+    /**
+     * Converts an Iceberg type to the corresponding Calcite SQL type.
+     *
+     * @param icebergType the Iceberg type
+     * @return the Calcite SQL type name
+     */
+    public static SqlTypeName toSqlTypeName(Type icebergType) {
+        switch (icebergType.typeId()) {
+            case BOOLEAN:
+                return SqlTypeName.BOOLEAN;
+            case INTEGER:
+                return SqlTypeName.INTEGER;
+            case LONG:
+                return SqlTypeName.BIGINT;
+            case FLOAT:
+                return SqlTypeName.FLOAT;
+            case DOUBLE:
+                return SqlTypeName.DOUBLE;
+            case DECIMAL:
+                return SqlTypeName.DECIMAL;
+            case DATE:
+                return SqlTypeName.DATE;
+            case TIME:
+                return SqlTypeName.TIME;
+            case TIMESTAMP:
+                return SqlTypeName.TIMESTAMP;
+            case STRING:
+                return SqlTypeName.VARCHAR;
+            case UUID:
+                return SqlTypeName.VARCHAR;
+            case FIXED:
+            case BINARY:
+                return SqlTypeName.VARBINARY;
+            default:
+                return SqlTypeName.VARCHAR;
+        }
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/schema/package-info.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/schema/package-info.java
@@ -1,0 +1,13 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Calcite schema integration for Iceberg tables.
+ * Maps Iceberg table metadata into the Calcite schema used by the analytics engine.
+ */
+package org.opensearch.lakehouse.schema;

--- a/sandbox/plugins/lakehouse-iceberg/src/main/plugin-metadata/plugin-security.policy
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/plugin-metadata/plugin-security.policy
@@ -7,6 +7,28 @@
  */
 
 grant {
-    // Network access for Glue catalog and S3 data reads
-    permission java.net.SocketPermission "*", "connect,resolve";
+  // Read ~/.aws/credentials and ~/.aws/config for credential resolution
+  permission java.io.FilePermission "${user.home}/.aws/-", "read";
+  permission java.io.FilePermission "${user.home}", "read";
+
+  // Connect to AWS endpoints (Glue, S3, STS)
+  permission java.net.SocketPermission "*", "connect,resolve";
+
+  // AWS SDK and Iceberg use reflection for client construction (DynConstructors, DynMethods)
+  permission java.lang.RuntimePermission "accessDeclaredMembers";
+  permission java.lang.RuntimePermission "getClassLoader";
+  permission java.lang.RuntimePermission "setContextClassLoader";
+  permission java.lang.reflect.ReflectPermission "suppressAccessChecks";
+
+  // AWS SDK reads aws.* system properties as part of credential chain fallback
+  permission java.util.PropertyPermission "aws.*", "read";
+  permission java.util.PropertyPermission "user.home", "read";
+
+  // Hadoop configuration reads system properties
+  permission java.util.PropertyPermission "hadoop.*", "read";
+  permission java.util.PropertyPermission "HADOOP_*", "read";
+
+  // Hadoop native library detection
+  permission java.util.PropertyPermission "os.name", "read";
+  permission java.util.PropertyPermission "os.arch", "read";
 };

--- a/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/LakehousePluginTests.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/LakehousePluginTests.java
@@ -8,9 +8,23 @@
 
 package org.opensearch.lakehouse;
 
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.opensearch.Version;
+import org.opensearch.analytics.schema.ExternalTable;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.common.settings.Setting;
+import org.opensearch.common.settings.Settings;
 import org.opensearch.test.OpenSearchTestCase;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class LakehousePluginTests extends OpenSearchTestCase {
 
@@ -18,5 +32,115 @@ public class LakehousePluginTests extends OpenSearchTestCase {
         try (LakehousePlugin plugin = new LakehousePlugin()) {
             assertNotNull(plugin);
         }
+    }
+
+    public void testGetSettingsReturnsAllSettings() throws IOException {
+        try (LakehousePlugin plugin = new LakehousePlugin()) {
+            List<Setting<?>> settings = plugin.getSettings();
+            assertNotNull(settings);
+            assertEquals(12, settings.size());
+        }
+    }
+
+    public void testClaimsLakehouseIndex() throws IOException {
+        try (LakehousePlugin plugin = new LakehousePlugin()) {
+            IndexMetadata idx = indexMetadata("iceberg_table", Settings.builder().put("index.lakehouse.enabled", true));
+            assertTrue(plugin.claims(idx));
+        }
+    }
+
+    public void testDoesNotClaimNormalIndex() throws IOException {
+        try (LakehousePlugin plugin = new LakehousePlugin()) {
+            IndexMetadata idx = indexMetadata("normal_index", Settings.builder());
+            assertFalse(plugin.claims(idx));
+        }
+    }
+
+    public void testSupportsIcebergFormat() throws IOException {
+        try (LakehousePlugin plugin = new LakehousePlugin()) {
+            ExternalTable icebergTable = mock(ExternalTable.class);
+            when(icebergTable.format()).thenReturn("iceberg");
+            assertTrue(plugin.supports(icebergTable));
+        }
+    }
+
+    public void testDoesNotSupportOtherFormats() throws IOException {
+        try (LakehousePlugin plugin = new LakehousePlugin()) {
+            ExternalTable deltaTable = mock(ExternalTable.class);
+            when(deltaTable.format()).thenReturn("delta");
+            assertFalse(plugin.supports(deltaTable));
+        }
+    }
+
+    public void testPrepareScanThrowsUnsupported() throws IOException {
+        try (LakehousePlugin plugin = new LakehousePlugin()) {
+            ExternalTable table = mock(ExternalTable.class);
+            expectThrows(UnsupportedOperationException.class, () -> plugin.prepareScan(null, table));
+        }
+    }
+
+    public void testContributeSchemaWithNoLakehouseIndices() throws IOException {
+        try (LakehousePlugin plugin = new LakehousePlugin()) {
+            IndexMetadata normalIdx = indexMetadata("normal_index", Settings.builder());
+            ClusterState state = clusterState(Map.of("normal_index", normalIdx));
+            SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+
+            plugin.contributeSchema(schema, state);
+
+            assertNull("Normal index should not be registered", schema.getTable("normal_index"));
+        }
+    }
+
+    public void testContributeSchemaWithLakehouseIndex() throws IOException {
+        try (LakehousePlugin plugin = new LakehousePlugin()) {
+            IndexMetadata lakehouseIdx = indexMetadata(
+                "my_iceberg",
+                Settings.builder()
+                    .put("index.lakehouse.enabled", true)
+                    .put("index.lakehouse.type", "glue")
+                    .put("index.lakehouse.warehouse", "s3://bucket")
+                    .put("index.lakehouse.namespace", "db")
+                    .put("index.lakehouse.table", "events")
+            );
+            ClusterState state = clusterState(Map.of("my_iceberg", lakehouseIdx));
+            SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+
+            plugin.contributeSchema(schema, state);
+
+            assertNotNull("Lakehouse index should be registered", schema.getTable("my_iceberg"));
+        }
+    }
+
+    public void testGetCatalogConnector() {
+        assertNotNull(LakehousePlugin.getCatalogConnector());
+    }
+
+    public void testSupportsNullFormat() throws IOException {
+        try (LakehousePlugin plugin = new LakehousePlugin()) {
+            ExternalTable table = mock(ExternalTable.class);
+            when(table.format()).thenReturn(null);
+            assertFalse(plugin.supports(table));
+        }
+    }
+
+    private static ClusterState clusterState(Map<String, IndexMetadata> indices) {
+        Metadata.Builder metadataBuilder = Metadata.builder();
+        for (Map.Entry<String, IndexMetadata> entry : indices.entrySet()) {
+            metadataBuilder.put(entry.getValue(), false);
+        }
+        ClusterState state = mock(ClusterState.class);
+        Metadata metadata = metadataBuilder.build();
+        when(state.metadata()).thenReturn(metadata);
+        return state;
+    }
+
+    private static IndexMetadata indexMetadata(String name, Settings.Builder extraSettings) {
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(extraSettings.build())
+            .build();
+        return IndexMetadata.builder(name).settings(settings).build();
     }
 }

--- a/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/catalog/AwsCredentialsTests.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/catalog/AwsCredentialsTests.java
@@ -1,0 +1,70 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.catalog;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class AwsCredentialsTests extends OpenSearchTestCase {
+
+    public void testIsComplete() {
+        AwsCredentials creds = new AwsCredentials("AKID", "SECRET", null);
+        assertTrue(creds.isComplete());
+    }
+
+    public void testIsCompleteWithSession() {
+        AwsCredentials creds = new AwsCredentials("AKID", "SECRET", "TOKEN");
+        assertTrue(creds.isComplete());
+    }
+
+    public void testIsNotCompleteNullAccessKey() {
+        AwsCredentials creds = new AwsCredentials(null, "SECRET", null);
+        assertFalse(creds.isComplete());
+    }
+
+    public void testIsNotCompleteEmptyAccessKey() {
+        AwsCredentials creds = new AwsCredentials("", "SECRET", null);
+        assertFalse(creds.isComplete());
+    }
+
+    public void testIsNotCompleteNullSecretKey() {
+        AwsCredentials creds = new AwsCredentials("AKID", null, null);
+        assertFalse(creds.isComplete());
+    }
+
+    public void testIsNotCompleteEmptySecretKey() {
+        AwsCredentials creds = new AwsCredentials("AKID", "", null);
+        assertFalse(creds.isComplete());
+    }
+
+    public void testNeverExpiresDefault() {
+        AwsCredentials creds = new AwsCredentials("AKID", "SECRET", null);
+        assertFalse(creds.isExpired());
+        assertEquals(0, creds.getExpiryTimestamp());
+    }
+
+    public void testNotExpiredFutureTimestamp() {
+        long futureMs = System.currentTimeMillis() + 3_600_000;
+        AwsCredentials creds = new AwsCredentials("AKID", "SECRET", "TOKEN", futureMs);
+        assertFalse(creds.isExpired());
+    }
+
+    public void testExpiredPastTimestamp() {
+        long pastMs = System.currentTimeMillis() - 1_000;
+        AwsCredentials creds = new AwsCredentials("AKID", "SECRET", "TOKEN", pastMs);
+        assertTrue(creds.isExpired());
+    }
+
+    public void testGetters() {
+        AwsCredentials creds = new AwsCredentials("AKID", "SECRET", "TOKEN", 12345L);
+        assertEquals("AKID", creds.getAccessKeyId());
+        assertEquals("SECRET", creds.getSecretAccessKey());
+        assertEquals("TOKEN", creds.getSessionToken());
+        assertEquals(12345L, creds.getExpiryTimestamp());
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/catalog/CatalogConfigTests.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/catalog/CatalogConfigTests.java
@@ -1,0 +1,181 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.catalog;
+
+import org.opensearch.Version;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class CatalogConfigTests extends OpenSearchTestCase {
+
+    public void testFromIndexSettings() {
+        IndexMetadata indexMetadata = indexMetadata(
+            "my_table",
+            Settings.builder()
+                .put("index.lakehouse.enabled", true)
+                .put("index.lakehouse.type", "glue")
+                .put("index.lakehouse.region", "us-west-2")
+                .put("index.lakehouse.warehouse", "s3://my-bucket/warehouse")
+                .put("index.lakehouse.namespace", "my_db")
+                .put("index.lakehouse.table", "events")
+                .put("index.lakehouse.auth_type", "role")
+                .put("index.lakehouse.role_arn", "arn:aws:iam::123456789012:role/my-role")
+                .put("index.lakehouse.credential_key", "my_cred")
+        );
+
+        CatalogConfig config = CatalogConfig.fromIndexSettings(indexMetadata);
+
+        assertEquals("my_table", config.indexName());
+        assertEquals(CatalogType.GLUE, config.catalogType());
+        assertEquals("us-west-2", config.region());
+        assertEquals("s3://my-bucket/warehouse", config.warehouse());
+        assertEquals("my_db", config.namespace());
+        assertEquals("events", config.tableName());
+        assertEquals("role", config.authType());
+        assertEquals("arn:aws:iam::123456789012:role/my-role", config.roleArn());
+        assertEquals("my_cred", config.credentialKey());
+    }
+
+    public void testFromIndexSettingsDefaultAuthType() {
+        IndexMetadata indexMetadata = indexMetadata(
+            "my_table",
+            Settings.builder()
+                .put("index.lakehouse.type", "hadoop")
+                .put("index.lakehouse.warehouse", "file:///tmp/warehouse")
+                .put("index.lakehouse.namespace", "default")
+                .put("index.lakehouse.table", "events")
+        );
+
+        CatalogConfig config = CatalogConfig.fromIndexSettings(indexMetadata);
+
+        assertEquals("default", config.authType());
+        assertEquals("", config.region());
+        assertEquals("", config.roleArn());
+    }
+
+    public void testFromIndexSettingsMissingType() {
+        IndexMetadata indexMetadata = indexMetadata(
+            "my_table",
+            Settings.builder()
+                .put("index.lakehouse.warehouse", "s3://bucket")
+                .put("index.lakehouse.namespace", "db")
+                .put("index.lakehouse.table", "t")
+        );
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> CatalogConfig.fromIndexSettings(indexMetadata));
+        assertTrue(e.getMessage().contains("index.lakehouse.type"));
+    }
+
+    public void testFromIndexSettingsMissingWarehouse() {
+        IndexMetadata indexMetadata = indexMetadata(
+            "my_table",
+            Settings.builder().put("index.lakehouse.type", "glue").put("index.lakehouse.namespace", "db").put("index.lakehouse.table", "t")
+        );
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> CatalogConfig.fromIndexSettings(indexMetadata));
+        assertTrue(e.getMessage().contains("index.lakehouse.warehouse"));
+    }
+
+    public void testFromIndexSettingsMissingNamespace() {
+        IndexMetadata indexMetadata = indexMetadata(
+            "my_table",
+            Settings.builder()
+                .put("index.lakehouse.type", "glue")
+                .put("index.lakehouse.warehouse", "s3://bucket")
+                .put("index.lakehouse.table", "t")
+        );
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> CatalogConfig.fromIndexSettings(indexMetadata));
+        assertTrue(e.getMessage().contains("index.lakehouse.namespace"));
+    }
+
+    public void testFromIndexSettingsMissingTable() {
+        IndexMetadata indexMetadata = indexMetadata(
+            "my_table",
+            Settings.builder()
+                .put("index.lakehouse.type", "glue")
+                .put("index.lakehouse.warehouse", "s3://bucket")
+                .put("index.lakehouse.namespace", "db")
+        );
+
+        IllegalArgumentException e = expectThrows(IllegalArgumentException.class, () -> CatalogConfig.fromIndexSettings(indexMetadata));
+        assertTrue(e.getMessage().contains("index.lakehouse.table"));
+    }
+
+    public void testConstructorNullIndexName() {
+        expectThrows(
+            NullPointerException.class,
+            () -> new CatalogConfig(null, CatalogType.GLUE, "us-west-2", "s3://b", "ns", "t", "default", null, null)
+        );
+    }
+
+    public void testConstructorNullCatalogType() {
+        expectThrows(
+            NullPointerException.class,
+            () -> new CatalogConfig("idx", null, "us-west-2", "s3://b", "ns", "t", "default", null, null)
+        );
+    }
+
+    public void testConstructorNullWarehouse() {
+        expectThrows(
+            NullPointerException.class,
+            () -> new CatalogConfig("idx", CatalogType.GLUE, "us-west-2", null, "ns", "t", "default", null, null)
+        );
+    }
+
+    public void testConstructorNullNamespace() {
+        expectThrows(
+            NullPointerException.class,
+            () -> new CatalogConfig("idx", CatalogType.GLUE, "us-west-2", "s3://b", null, "t", "default", null, null)
+        );
+    }
+
+    public void testConstructorNullTableName() {
+        expectThrows(
+            NullPointerException.class,
+            () -> new CatalogConfig("idx", CatalogType.GLUE, "us-west-2", "s3://b", "ns", null, "default", null, null)
+        );
+    }
+
+    public void testConstructorNullAuthTypeDefaultsToDefault() {
+        CatalogConfig config = new CatalogConfig("idx", CatalogType.GLUE, "us-west-2", "s3://b", "ns", "t", null, null, null);
+        assertEquals("default", config.authType());
+    }
+
+    public void testConstructorEmptyAuthTypeDefaultsToDefault() {
+        CatalogConfig config = new CatalogConfig("idx", CatalogType.GLUE, "us-west-2", "s3://b", "ns", "t", "", null, null);
+        assertEquals("default", config.authType());
+    }
+
+    public void testCredentialKeyAccessor() {
+        CatalogConfig config = new CatalogConfig("idx", CatalogType.GLUE, "us-west-2", "s3://b", "ns", "t", "keys", null, "my_cred_key");
+        assertEquals("my_cred_key", config.credentialKey());
+    }
+
+    public void testRegionCanBeNull() {
+        CatalogConfig config = new CatalogConfig("idx", CatalogType.HADOOP, null, "file:///tmp", "ns", "t", "default", null, null);
+        assertNull(config.region());
+    }
+
+    public void testRoleArnCanBeNull() {
+        CatalogConfig config = new CatalogConfig("idx", CatalogType.GLUE, "us-west-2", "s3://b", "ns", "t", "default", null, null);
+        assertNull(config.roleArn());
+    }
+
+    private static IndexMetadata indexMetadata(String name, Settings.Builder extraSettings) {
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(extraSettings.build())
+            .build();
+        return IndexMetadata.builder(name).settings(settings).build();
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/catalog/CatalogTypeTests.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/catalog/CatalogTypeTests.java
@@ -1,0 +1,34 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.catalog;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+public class CatalogTypeTests extends OpenSearchTestCase {
+
+    public void testFromStringGlue() {
+        assertEquals(CatalogType.GLUE, CatalogType.fromString("glue"));
+        assertEquals(CatalogType.GLUE, CatalogType.fromString("GLUE"));
+        assertEquals(CatalogType.GLUE, CatalogType.fromString("Glue"));
+    }
+
+    public void testFromStringHadoop() {
+        assertEquals(CatalogType.HADOOP, CatalogType.fromString("hadoop"));
+        assertEquals(CatalogType.HADOOP, CatalogType.fromString("HADOOP"));
+    }
+
+    public void testFromStringRest() {
+        assertEquals(CatalogType.REST, CatalogType.fromString("rest"));
+        assertEquals(CatalogType.REST, CatalogType.fromString("REST"));
+    }
+
+    public void testFromStringInvalid() {
+        expectThrows(IllegalArgumentException.class, () -> CatalogType.fromString("invalid"));
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/catalog/LakehouseCredentialsProviderTests.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/catalog/LakehouseCredentialsProviderTests.java
@@ -1,0 +1,90 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.catalog;
+
+import software.amazon.awssdk.core.exception.SdkClientException;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+
+public class LakehouseCredentialsProviderTests extends OpenSearchTestCase {
+
+    @Override
+    public void tearDown() throws Exception {
+        LakehouseCredentialsProvider.clear();
+        super.tearDown();
+    }
+
+    public void testSetAndResolveBasicCredentials() {
+        AwsCredentials creds = new AwsCredentials("AKID", "SECRET", null);
+        LakehouseCredentialsProvider.set(creds);
+
+        LakehouseCredentialsProvider provider = new LakehouseCredentialsProvider();
+        software.amazon.awssdk.auth.credentials.AwsCredentials resolved = provider.resolveCredentials();
+
+        assertEquals("AKID", resolved.accessKeyId());
+        assertEquals("SECRET", resolved.secretAccessKey());
+        assertFalse(resolved instanceof software.amazon.awssdk.auth.credentials.AwsSessionCredentials);
+    }
+
+    public void testSetAndResolveSessionCredentials() {
+        AwsCredentials creds = new AwsCredentials("AKID", "SECRET", "TOKEN");
+        LakehouseCredentialsProvider.set(creds);
+
+        LakehouseCredentialsProvider provider = new LakehouseCredentialsProvider();
+        software.amazon.awssdk.auth.credentials.AwsCredentials resolved = provider.resolveCredentials();
+
+        assertTrue(resolved instanceof software.amazon.awssdk.auth.credentials.AwsSessionCredentials);
+        software.amazon.awssdk.auth.credentials.AwsSessionCredentials session =
+            (software.amazon.awssdk.auth.credentials.AwsSessionCredentials) resolved;
+        assertEquals("AKID", session.accessKeyId());
+        assertEquals("SECRET", session.secretAccessKey());
+        assertEquals("TOKEN", session.sessionToken());
+    }
+
+    public void testResolveThrowsWhenNoCredentialsSet() {
+        LakehouseCredentialsProvider provider = new LakehouseCredentialsProvider();
+        expectThrows(SdkClientException.class, provider::resolveCredentials);
+    }
+
+    public void testResolveThrowsWhenIncompleteCredentials() {
+        LakehouseCredentialsProvider.set(new AwsCredentials(null, "SECRET", null));
+        LakehouseCredentialsProvider provider = new LakehouseCredentialsProvider();
+        expectThrows(SdkClientException.class, provider::resolveCredentials);
+    }
+
+    public void testClearRemovesCredentials() {
+        LakehouseCredentialsProvider.set(new AwsCredentials("AKID", "SECRET", null));
+        LakehouseCredentialsProvider.clear();
+
+        LakehouseCredentialsProvider provider = new LakehouseCredentialsProvider();
+        expectThrows(SdkClientException.class, provider::resolveCredentials);
+    }
+
+    public void testGetReturnsSetCredentials() {
+        AwsCredentials creds = new AwsCredentials("AKID", "SECRET", null);
+        LakehouseCredentialsProvider.set(creds);
+        assertSame(creds, LakehouseCredentialsProvider.get());
+    }
+
+    public void testGetReturnsNullWhenNotSet() {
+        assertNull(LakehouseCredentialsProvider.get());
+    }
+
+    public void testCreateFactoryWithProperties() {
+        LakehouseCredentialsProvider provider = LakehouseCredentialsProvider.create(Map.of("key", "val"));
+        assertNotNull(provider);
+    }
+
+    public void testCreateFactoryNoArgs() {
+        LakehouseCredentialsProvider provider = LakehouseCredentialsProvider.create();
+        assertNotNull(provider);
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/schema/IcebergCalciteTableTests.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/schema/IcebergCalciteTableTests.java
@@ -1,0 +1,155 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.schema;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.iceberg.Schema;
+import org.apache.iceberg.Snapshot;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.types.Types;
+import org.opensearch.lakehouse.catalog.CatalogConfig;
+import org.opensearch.lakehouse.catalog.CatalogType;
+import org.opensearch.lakehouse.catalog.IcebergCatalogConnector;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class IcebergCalciteTableTests extends OpenSearchTestCase {
+
+    private CatalogConfig config;
+    private IcebergCatalogConnector connector;
+    private Table mockTable;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        config = new CatalogConfig("test_idx", CatalogType.GLUE, "us-west-2", "s3://bucket", "db", "events", "default", null, null);
+        connector = mock(IcebergCatalogConnector.class);
+        mockTable = mock(Table.class);
+
+        Schema schema = new Schema(
+            Types.NestedField.required(1, "id", Types.LongType.get()),
+            Types.NestedField.optional(2, "name", Types.StringType.get()),
+            Types.NestedField.optional(3, "amount", Types.DecimalType.of(10, 2)),
+            Types.NestedField.optional(4, "active", Types.BooleanType.get())
+        );
+        Snapshot snapshot = mock(Snapshot.class);
+        when(snapshot.snapshotId()).thenReturn(42L);
+        when(mockTable.schema()).thenReturn(schema);
+        when(mockTable.currentSnapshot()).thenReturn(snapshot);
+        when(connector.loadTable(config)).thenReturn(mockTable);
+    }
+
+    public void testQualifiedName() {
+        IcebergCalciteTable table = new IcebergCalciteTable(config, connector);
+        assertEquals("db.events", table.qualifiedName());
+    }
+
+    public void testFormat() {
+        IcebergCalciteTable table = new IcebergCalciteTable(config, connector);
+        assertEquals("iceberg", table.format());
+    }
+
+    public void testSnapshotIdBeforeLoad() {
+        IcebergCalciteTable table = new IcebergCalciteTable(config, connector);
+        assertEquals(-1L, table.snapshotId());
+    }
+
+    public void testGetRowTypeTriggersLazyLoad() {
+        IcebergCalciteTable table = new IcebergCalciteTable(config, connector);
+
+        RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+        RelDataType rowType = table.getRowType(typeFactory);
+
+        verify(connector, times(1)).loadTable(config);
+        assertEquals(4, rowType.getFieldCount());
+        assertEquals("id", rowType.getFieldList().get(0).getName());
+        assertEquals(SqlTypeName.BIGINT, rowType.getFieldList().get(0).getType().getSqlTypeName());
+        assertFalse(rowType.getFieldList().get(0).getType().isNullable());
+        assertEquals("name", rowType.getFieldList().get(1).getName());
+        assertEquals(SqlTypeName.VARCHAR, rowType.getFieldList().get(1).getType().getSqlTypeName());
+        assertTrue(rowType.getFieldList().get(1).getType().isNullable());
+        assertEquals("amount", rowType.getFieldList().get(2).getName());
+        assertEquals(SqlTypeName.DECIMAL, rowType.getFieldList().get(2).getType().getSqlTypeName());
+        assertEquals(10, rowType.getFieldList().get(2).getType().getPrecision());
+        assertEquals(2, rowType.getFieldList().get(2).getType().getScale());
+        assertEquals("active", rowType.getFieldList().get(3).getName());
+        assertEquals(SqlTypeName.BOOLEAN, rowType.getFieldList().get(3).getType().getSqlTypeName());
+    }
+
+    public void testGetRowTypeCalledTwiceLoadsOnce() {
+        IcebergCalciteTable table = new IcebergCalciteTable(config, connector);
+
+        RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+        table.getRowType(typeFactory);
+        table.getRowType(typeFactory);
+
+        verify(connector, times(1)).loadTable(config);
+    }
+
+    public void testSnapshotIdAfterLoad() {
+        IcebergCalciteTable table = new IcebergCalciteTable(config, connector);
+
+        RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+        table.getRowType(typeFactory);
+
+        assertEquals(42L, table.snapshotId());
+    }
+
+    public void testSnapshotIdNullSnapshot() {
+        when(mockTable.currentSnapshot()).thenReturn(null);
+
+        IcebergCalciteTable table = new IcebergCalciteTable(config, connector);
+        RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+        table.getRowType(typeFactory);
+
+        assertEquals(-1L, table.snapshotId());
+    }
+
+    public void testCatalogConfig() {
+        IcebergCalciteTable table = new IcebergCalciteTable(config, connector);
+        assertSame(config, table.catalogConfig());
+    }
+
+    public void testConcurrentGetRowTypeLoadsOnce() throws Exception {
+        IcebergCalciteTable table = new IcebergCalciteTable(config, connector);
+        int threadCount = 4;
+        CyclicBarrier barrier = new CyclicBarrier(threadCount);
+        AtomicInteger errors = new AtomicInteger(0);
+
+        Thread[] threads = new Thread[threadCount];
+        for (int i = 0; i < threadCount; i++) {
+            threads[i] = new Thread(() -> {
+                try {
+                    barrier.await();
+                    RelDataTypeFactory typeFactory = new JavaTypeFactoryImpl();
+                    RelDataType rowType = table.getRowType(typeFactory);
+                    assertEquals(4, rowType.getFieldCount());
+                } catch (Exception e) {
+                    errors.incrementAndGet();
+                }
+            });
+            threads[i].start();
+        }
+        for (Thread t : threads) {
+            t.join(5000);
+        }
+        assertEquals(0, errors.get());
+        verify(connector, times(1)).loadTable(config);
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/schema/IcebergSchemaContributorTests.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/schema/IcebergSchemaContributorTests.java
@@ -1,0 +1,124 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.schema;
+
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.schema.SchemaPlus;
+import org.apache.calcite.schema.Table;
+import org.opensearch.Version;
+import org.opensearch.cluster.ClusterState;
+import org.opensearch.cluster.metadata.IndexMetadata;
+import org.opensearch.cluster.metadata.Metadata;
+import org.opensearch.common.settings.Settings;
+import org.opensearch.lakehouse.catalog.IcebergCatalogConnector;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class IcebergSchemaContributorTests extends OpenSearchTestCase {
+
+    private IcebergCatalogConnector connector;
+    private IcebergSchemaContributor contributor;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        connector = mock(IcebergCatalogConnector.class);
+        contributor = new IcebergSchemaContributor(connector);
+    }
+
+    public void testClaimsLakehouseIndex() {
+        IndexMetadata idx = indexMetadata("iceberg_table", Settings.builder().put("index.lakehouse.enabled", true));
+        assertTrue(contributor.claims(idx));
+    }
+
+    public void testDoesNotClaimNormalIndex() {
+        IndexMetadata idx = indexMetadata("normal_index", Settings.builder());
+        assertFalse(contributor.claims(idx));
+    }
+
+    public void testDoesNotClaimExplicitlyDisabled() {
+        IndexMetadata idx = indexMetadata("disabled_table", Settings.builder().put("index.lakehouse.enabled", false));
+        assertFalse(contributor.claims(idx));
+    }
+
+    public void testContributeSchemaRegistersLakehouseIndices() {
+        IndexMetadata lakehouseIdx = indexMetadata(
+            "my_iceberg",
+            Settings.builder()
+                .put("index.lakehouse.enabled", true)
+                .put("index.lakehouse.type", "glue")
+                .put("index.lakehouse.warehouse", "s3://bucket")
+                .put("index.lakehouse.namespace", "db")
+                .put("index.lakehouse.table", "events")
+        );
+        IndexMetadata normalIdx = indexMetadata("logs", Settings.builder());
+
+        ClusterState state = clusterState(Map.of("my_iceberg", lakehouseIdx, "logs", normalIdx));
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+
+        contributor.contributeSchema(schema, state);
+
+        Table registered = schema.getTable("my_iceberg");
+        assertNotNull("Lakehouse index should be registered", registered);
+        assertTrue(registered instanceof IcebergCalciteTable);
+
+        assertNull("Normal index should not be registered by contributor", schema.getTable("logs"));
+    }
+
+    public void testContributeSchemaSkipsNormalIndices() {
+        IndexMetadata normalIdx = indexMetadata("logs", Settings.builder());
+
+        ClusterState state = clusterState(Map.of("logs", normalIdx));
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+
+        contributor.contributeSchema(schema, state);
+
+        assertNull(schema.getTable("logs"));
+    }
+
+    public void testContributeSchemaHandlesInvalidConfig() {
+        // Missing required settings — fromIndexSettings will throw
+        IndexMetadata badIdx = indexMetadata("bad_table", Settings.builder().put("index.lakehouse.enabled", true)
+        // missing type, warehouse, namespace, table
+        );
+
+        ClusterState state = clusterState(Map.of("bad_table", badIdx));
+        SchemaPlus schema = CalciteSchema.createRootSchema(true).plus();
+
+        // Should not throw — error is caught and logged
+        contributor.contributeSchema(schema, state);
+
+        assertNull("Invalid config should not register a table", schema.getTable("bad_table"));
+    }
+
+    private static IndexMetadata indexMetadata(String name, Settings.Builder extraSettings) {
+        Settings settings = Settings.builder()
+            .put(IndexMetadata.SETTING_VERSION_CREATED, Version.CURRENT)
+            .put(IndexMetadata.SETTING_NUMBER_OF_SHARDS, 1)
+            .put(IndexMetadata.SETTING_NUMBER_OF_REPLICAS, 0)
+            .put(extraSettings.build())
+            .build();
+        return IndexMetadata.builder(name).settings(settings).build();
+    }
+
+    private static ClusterState clusterState(Map<String, IndexMetadata> indices) {
+        Metadata.Builder metadataBuilder = Metadata.builder();
+        for (Map.Entry<String, IndexMetadata> entry : indices.entrySet()) {
+            metadataBuilder.put(entry.getValue(), false);
+        }
+        ClusterState state = mock(ClusterState.class);
+        Metadata metadata = metadataBuilder.build();
+        when(state.metadata()).thenReturn(metadata);
+        return state;
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/schema/IcebergTypeMapperTests.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/schema/IcebergTypeMapperTests.java
@@ -1,0 +1,85 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.schema;
+
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.iceberg.types.Types;
+import org.opensearch.test.OpenSearchTestCase;
+
+public class IcebergTypeMapperTests extends OpenSearchTestCase {
+
+    public void testBooleanType() {
+        assertEquals(SqlTypeName.BOOLEAN, IcebergTypeMapper.toSqlTypeName(Types.BooleanType.get()));
+    }
+
+    public void testIntegerType() {
+        assertEquals(SqlTypeName.INTEGER, IcebergTypeMapper.toSqlTypeName(Types.IntegerType.get()));
+    }
+
+    public void testLongType() {
+        assertEquals(SqlTypeName.BIGINT, IcebergTypeMapper.toSqlTypeName(Types.LongType.get()));
+    }
+
+    public void testFloatType() {
+        assertEquals(SqlTypeName.FLOAT, IcebergTypeMapper.toSqlTypeName(Types.FloatType.get()));
+    }
+
+    public void testDoubleType() {
+        assertEquals(SqlTypeName.DOUBLE, IcebergTypeMapper.toSqlTypeName(Types.DoubleType.get()));
+    }
+
+    public void testDecimalType() {
+        assertEquals(SqlTypeName.DECIMAL, IcebergTypeMapper.toSqlTypeName(Types.DecimalType.of(10, 2)));
+    }
+
+    public void testDateType() {
+        assertEquals(SqlTypeName.DATE, IcebergTypeMapper.toSqlTypeName(Types.DateType.get()));
+    }
+
+    public void testTimeType() {
+        assertEquals(SqlTypeName.TIME, IcebergTypeMapper.toSqlTypeName(Types.TimeType.get()));
+    }
+
+    public void testTimestampType() {
+        assertEquals(SqlTypeName.TIMESTAMP, IcebergTypeMapper.toSqlTypeName(Types.TimestampType.withoutZone()));
+    }
+
+    public void testTimestampTzType() {
+        assertEquals(SqlTypeName.TIMESTAMP, IcebergTypeMapper.toSqlTypeName(Types.TimestampType.withZone()));
+    }
+
+    public void testStringType() {
+        assertEquals(SqlTypeName.VARCHAR, IcebergTypeMapper.toSqlTypeName(Types.StringType.get()));
+    }
+
+    public void testUuidType() {
+        assertEquals(SqlTypeName.VARCHAR, IcebergTypeMapper.toSqlTypeName(Types.UUIDType.get()));
+    }
+
+    public void testBinaryType() {
+        assertEquals(SqlTypeName.VARBINARY, IcebergTypeMapper.toSqlTypeName(Types.BinaryType.get()));
+    }
+
+    public void testFixedType() {
+        assertEquals(SqlTypeName.VARBINARY, IcebergTypeMapper.toSqlTypeName(Types.FixedType.ofLength(16)));
+    }
+
+    public void testUnsupportedTypeFallsBackToVarchar() {
+        // LIST, MAP, STRUCT are not explicitly handled — they hit the default branch
+        assertEquals(SqlTypeName.VARCHAR, IcebergTypeMapper.toSqlTypeName(Types.ListType.ofRequired(1, Types.StringType.get())));
+        assertEquals(
+            SqlTypeName.VARCHAR,
+            IcebergTypeMapper.toSqlTypeName(Types.MapType.ofRequired(1, 2, Types.StringType.get(), Types.StringType.get()))
+        );
+        assertEquals(
+            SqlTypeName.VARCHAR,
+            IcebergTypeMapper.toSqlTypeName(Types.StructType.of(Types.NestedField.required(1, "field", Types.StringType.get())))
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Adds the catalog infrastructure that connects OpenSearch's Calcite-based analytics engine to Apache Iceberg tables:

- **Schema routing via `claims()`**: `SchemaContributor` gains a `claims(IndexMetadata)` method so lakehouse indices are handled by the Iceberg plugin instead of the default `OpenSearchSchemaBuilder` — prevents name collisions
- **`IcebergCatalogConnector`**: Manages Iceberg `Catalog` lifecycle with per-index credential caching, auto-refresh on STS token expiry, and `ThreadLocal`-based credential propagation to the Iceberg SDK
- **Three authentication modes**: `role` (STS AssumeRole with `role_arn`), `keys` (keystore-backed, pending full wiring), `default` (environment credential chain)
- **`IcebergCalciteTable`**: Maps Iceberg table schema to Calcite `RelDataType` via `IcebergTypeMapper`, pins snapshot ID at construction for consistent reads, implements `ExternalTable` for downstream scan planning
- **`IcebergSchemaContributor`**: Discovers all `index.lakehouse.enabled=true` indices from cluster state and registers them as Calcite tables

## Changes

### analytics-framework (SPI library)
- `SchemaContributor.claims(IndexMetadata)` — new default method for index ownership routing

### analytics-engine (hub plugin)
- `OpenSearchSchemaBuilder.buildSchema(ClusterState, Set<String>)` — skips claimed indices
- `AnalyticsPlugin.DefaultEngineContext.getSchema()` — collects claimed indices, passes to builder, then calls each contributor

### lakehouse-iceberg (this plugin)
- **catalog package**: `CatalogType`, `AwsCredentials`, `CatalogConfig`, `LakehouseCredentialsProvider`, `IcebergCatalogConnector`
- **schema package**: `IcebergTypeMapper`, `IcebergCalciteTable`, `IcebergSchemaContributor`
- `LakehousePlugin` — delegates `claims()` and `contributeSchema()` to `IcebergSchemaContributor`
- `build.gradle` — Iceberg SDK 1.7.1, AWS SDK v2, Hadoop client deps
- `plugin-security.policy` — permissions for AWS, Hadoop, reflection

## Test plan

- [x] Unit tests: `CatalogTypeTests`, `AwsCredentialsTests`, `IcebergTypeMapperTests`
- [x] `./gradlew :sandbox:plugins:lakehouse-iceberg:test` — all pass
- [x] `spotlessCheck`, `jarHell`, `javadoc` — all pass
- [ ] Integration test with real Iceberg table (manual, requires AWS credentials)