### PR TITLE
fix(datafusion): return empty list instead of null from getSupportedFormats()

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -118,7 +118,7 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
      * Data formats this plugin can handle. Used by CompositeEngine to route queries.
      */
     public List<DataFormat> getSupportedFormats() {
-        return null; // TODO : List.of("parquet");
+        return List.of(); // TODO : List.of("parquet");
     }
 
     @Override


### PR DESCRIPTION
## Summary
- `DataFusionPlugin.getSupportedFormats()` returns `null`, causing NPE in `DataFormatRegistry` which calls `.iterator()` on the result
- Fix: return `List.of()` instead of `null`

## Test plan
- `./gradlew run` with all plugins no longer crashes on startup