### PR TITLE
feat(lakehouse): scan planning and predicate pushdown for Iceberg tables

### DIFF
--- a/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
+++ b/sandbox/plugins/analytics-backend-datafusion/src/main/java/org/opensearch/be/datafusion/DataFusionPlugin.java
@@ -118,7 +118,7 @@ public class DataFusionPlugin extends Plugin implements SearchBackEndPlugin<Data
      * Data formats this plugin can handle. Used by CompositeEngine to route queries.
      */
     public List<DataFormat> getSupportedFormats() {
-        return null; // TODO : List.of("parquet");
+        return List.of(); // TODO : List.of("parquet");
     }
 
     @Override

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/scan/CalciteToIcebergPredicateConverter.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/scan/CalciteToIcebergPredicateConverter.java
@@ -1,0 +1,277 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.scan;
+
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.List;
+
+/**
+ * Converts Calcite {@link RexNode} filter expressions into Iceberg {@link Expression} predicates
+ * for predicate pushdown into Iceberg table scans.
+ *
+ * <p>Unsupported or unrecognized predicates safely fall back to {@link Expressions#alwaysTrue()},
+ * which ensures no data is incorrectly skipped.</p>
+ */
+public final class CalciteToIcebergPredicateConverter {
+
+    private CalciteToIcebergPredicateConverter() {}
+
+    /**
+     * Converts a Calcite filter expression into an Iceberg predicate.
+     *
+     * @param rexNode the Calcite filter expression
+     * @param rowType the row type used to resolve column names from {@link RexInputRef} indices
+     * @return an Iceberg {@link Expression}, or {@link Expressions#alwaysTrue()} for unsupported predicates
+     */
+    public static Expression convert(RexNode rexNode, RelDataType rowType) {
+        if (!(rexNode instanceof RexCall)) {
+            return Expressions.alwaysTrue();
+        }
+        RexCall call = (RexCall) rexNode;
+        switch (call.getKind()) {
+            case EQUALS:
+                return convertComparison(call, rowType, ComparisonOp.EQ);
+            case NOT_EQUALS:
+                return convertComparison(call, rowType, ComparisonOp.NOT_EQ);
+            case GREATER_THAN:
+                return convertComparison(call, rowType, ComparisonOp.GT);
+            case GREATER_THAN_OR_EQUAL:
+                return convertComparison(call, rowType, ComparisonOp.GT_EQ);
+            case LESS_THAN:
+                return convertComparison(call, rowType, ComparisonOp.LT);
+            case LESS_THAN_OR_EQUAL:
+                return convertComparison(call, rowType, ComparisonOp.LT_EQ);
+            case AND:
+                return convertLogical(call, rowType, true);
+            case OR:
+                return convertLogical(call, rowType, false);
+            case NOT:
+                Expression inner = convert(call.getOperands().get(0), rowType);
+                // If the inner expression couldn't be converted (alwaysTrue fallback),
+                // don't negate it — NOT(alwaysTrue) = alwaysFalse would incorrectly prune all files.
+                if (inner.op() == Expression.Operation.TRUE) {
+                    return Expressions.alwaysTrue();
+                }
+                return Expressions.not(inner);
+            case IS_NULL:
+                return convertIsNull(call, rowType);
+            case IS_NOT_NULL:
+                return convertIsNotNull(call, rowType);
+            case IN:
+                return convertIn(call, rowType);
+            default:
+                return Expressions.alwaysTrue();
+        }
+    }
+
+    private enum ComparisonOp {
+        EQ,
+        NOT_EQ,
+        GT,
+        GT_EQ,
+        LT,
+        LT_EQ
+    }
+
+    private static Expression convertComparison(RexCall call, RelDataType rowType, ComparisonOp op) {
+        List<RexNode> operands = call.getOperands();
+        if (operands.size() != 2) {
+            return Expressions.alwaysTrue();
+        }
+
+        String colName = extractColumnName(operands.get(0), rowType);
+        Object value = extractLiteralValue(operands.get(1));
+
+        // Try flipped operands: literal op column
+        if (colName == null || value == null) {
+            colName = extractColumnName(operands.get(1), rowType);
+            value = extractLiteralValue(operands.get(0));
+            if (colName == null || value == null) {
+                return Expressions.alwaysTrue();
+            }
+            op = flipOp(op);
+        }
+
+        value = coerceValue(value, colName, rowType);
+
+        switch (op) {
+            case EQ:
+                return Expressions.equal(colName, value);
+            case NOT_EQ:
+                return Expressions.notEqual(colName, value);
+            case GT:
+                return Expressions.greaterThan(colName, value);
+            case GT_EQ:
+                return Expressions.greaterThanOrEqual(colName, value);
+            case LT:
+                return Expressions.lessThan(colName, value);
+            case LT_EQ:
+                return Expressions.lessThanOrEqual(colName, value);
+            default:
+                return Expressions.alwaysTrue();
+        }
+    }
+
+    private static ComparisonOp flipOp(ComparisonOp op) {
+        switch (op) {
+            case GT:
+                return ComparisonOp.LT;
+            case GT_EQ:
+                return ComparisonOp.LT_EQ;
+            case LT:
+                return ComparisonOp.GT;
+            case LT_EQ:
+                return ComparisonOp.GT_EQ;
+            default:
+                return op;
+        }
+    }
+
+    private static Expression convertLogical(RexCall call, RelDataType rowType, boolean isAnd) {
+        List<RexNode> operands = call.getOperands();
+        if (operands.isEmpty()) {
+            return Expressions.alwaysTrue();
+        }
+        Expression result = convert(operands.get(0), rowType);
+        for (int i = 1; i < operands.size(); i++) {
+            Expression next = convert(operands.get(i), rowType);
+            result = isAnd ? Expressions.and(result, next) : Expressions.or(result, next);
+        }
+        return result;
+    }
+
+    private static Expression convertIsNull(RexCall call, RelDataType rowType) {
+        if (call.getOperands().size() != 1) {
+            return Expressions.alwaysTrue();
+        }
+        String colName = extractColumnName(call.getOperands().get(0), rowType);
+        if (colName == null) {
+            return Expressions.alwaysTrue();
+        }
+        return Expressions.isNull(colName);
+    }
+
+    private static Expression convertIsNotNull(RexCall call, RelDataType rowType) {
+        if (call.getOperands().size() != 1) {
+            return Expressions.alwaysTrue();
+        }
+        String colName = extractColumnName(call.getOperands().get(0), rowType);
+        if (colName == null) {
+            return Expressions.alwaysTrue();
+        }
+        return Expressions.notNull(colName);
+    }
+
+    private static Expression convertIn(RexCall call, RelDataType rowType) {
+        List<RexNode> operands = call.getOperands();
+        if (operands.size() < 2) {
+            return Expressions.alwaysTrue();
+        }
+        String colName = extractColumnName(operands.get(0), rowType);
+        if (colName == null) {
+            return Expressions.alwaysTrue();
+        }
+        Expression result = null;
+        for (int i = 1; i < operands.size(); i++) {
+            Object value = extractLiteralValue(operands.get(i));
+            if (value == null) {
+                return Expressions.alwaysTrue();
+            }
+            Expression eq = Expressions.equal(colName, value);
+            result = (result == null) ? eq : Expressions.or(result, eq);
+        }
+        return result != null ? result : Expressions.alwaysTrue();
+    }
+
+    private static String extractColumnName(RexNode node, RelDataType rowType) {
+        if (node instanceof RexInputRef) {
+            int index = ((RexInputRef) node).getIndex();
+            return rowType.getFieldList().get(index).getName();
+        }
+        return null;
+    }
+
+    /**
+     * Coerces a literal value (typically BigDecimal from Calcite) to the Java type
+     * expected by Iceberg for the given column.
+     */
+    private static Object coerceValue(Object value, String colName, RelDataType rowType) {
+        if (!(value instanceof BigDecimal)) {
+            return value;
+        }
+        BigDecimal bd = (BigDecimal) value;
+        for (int i = 0; i < rowType.getFieldCount(); i++) {
+            if (rowType.getFieldList().get(i).getName().equals(colName)) {
+                SqlTypeName typeName = rowType.getFieldList().get(i).getType().getSqlTypeName();
+                switch (typeName) {
+                    case INTEGER:
+                        return bd.intValue();
+                    case BIGINT:
+                        return bd.longValue();
+                    case FLOAT:
+                    case REAL:
+                        return bd.floatValue();
+                    case DOUBLE:
+                        return bd.doubleValue();
+                    case DECIMAL:
+                        // Iceberg rejects scale mismatches — ensure BigDecimal has the column's scale
+                        int scale = rowType.getFieldList().get(i).getType().getScale();
+                        return bd.setScale(scale, RoundingMode.HALF_UP);
+                    default:
+                        return value;
+                }
+            }
+        }
+        return value;
+    }
+
+    private static Object extractLiteralValue(RexNode node) {
+        if (node instanceof RexLiteral) {
+            RexLiteral literal = (RexLiteral) node;
+            SqlTypeName typeName = literal.getTypeName();
+            if (typeName == SqlTypeName.CHAR || typeName == SqlTypeName.VARCHAR) {
+                return literal.getValueAs(String.class);
+            }
+            // Timestamp literals: Iceberg expects microseconds since epoch (long)
+            if (typeName == SqlTypeName.TIMESTAMP || typeName == SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE) {
+                Long millis = literal.getValueAs(Long.class);
+                return millis != null ? millis * 1000L : null; // millis → micros
+            }
+            // Date literals: Iceberg expects days since epoch (int)
+            if (typeName == SqlTypeName.DATE) {
+                return literal.getValueAs(Integer.class);
+            }
+            // Time literals: Iceberg expects microseconds since midnight (long)
+            if (typeName == SqlTypeName.TIME) {
+                Integer millis = literal.getValueAs(Integer.class);
+                return millis != null ? (long) millis * 1000L : null; // millis → micros
+            }
+            return literal.getValueAs(Comparable.class);
+        }
+        // Handle CAST(literal) — Calcite wraps literals in CAST when types differ
+        if (node instanceof RexCall) {
+            RexCall call = (RexCall) node;
+            if (call.getKind() == SqlKind.CAST && call.getOperands().size() == 1) {
+                return extractLiteralValue(call.getOperands().get(0));
+            }
+        }
+        return null;
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/scan/IcebergScanPlan.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/scan/IcebergScanPlan.java
@@ -1,0 +1,83 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.scan;
+
+import java.util.List;
+
+/**
+ * Result of Iceberg scan planning: pruned file paths with metadata.
+ */
+public class IcebergScanPlan {
+
+    /** Metadata about a single data file in the scan plan. */
+    public static class FileInfo {
+        private final String path;
+        private final long fileSizeInBytes;
+
+        /**
+         * Creates file info with the given path and size.
+         *
+         * @param path            the data file path
+         * @param fileSizeInBytes the file size in bytes
+         */
+        public FileInfo(String path, long fileSizeInBytes) {
+            this.path = path;
+            this.fileSizeInBytes = fileSizeInBytes;
+        }
+
+        /** Returns the data file path. */
+        public String getPath() {
+            return path;
+        }
+
+        /** Returns the file size in bytes. */
+        public long getFileSizeInBytes() {
+            return fileSizeInBytes;
+        }
+    }
+
+    private final List<FileInfo> files;
+    private final List<String> projectedColumns;
+
+    /**
+     * Creates a scan plan with the given files and projected columns.
+     *
+     * @param files            the pruned list of data files
+     * @param projectedColumns the columns to project
+     */
+    public IcebergScanPlan(List<FileInfo> files, List<String> projectedColumns) {
+        this.files = files;
+        this.projectedColumns = projectedColumns;
+    }
+
+    /** Returns the list of data files in the scan plan. */
+    public List<FileInfo> getFiles() {
+        return files;
+    }
+
+    /** Returns the projected column names. */
+    public List<String> getProjectedColumns() {
+        return projectedColumns;
+    }
+
+    /** Returns just the file paths from the scan plan. */
+    public List<String> getDataFilePaths() {
+        return files.stream().map(FileInfo::getPath).toList();
+    }
+
+    /** Returns the total size of all files in bytes. */
+    public long getTotalFileSize() {
+        return files.stream().mapToLong(FileInfo::getFileSizeInBytes).sum();
+    }
+
+    /** Returns the number of data files in the scan plan. */
+    public int fileCount() {
+        return files.size();
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/scan/IcebergScanPlanner.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/scan/IcebergScanPlanner.java
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.scan;
+
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+/**
+ * Plans Iceberg table scans with predicate pushdown and parallel manifest fetching.
+ */
+public class IcebergScanPlanner {
+
+    private final ExecutorService executorService;
+
+    /**
+     * Creates a scan planner with the given executor for parallel manifest fetching.
+     *
+     * @param executorService executor for parallel operations
+     */
+    public IcebergScanPlanner(ExecutorService executorService) {
+        this.executorService = executorService;
+    }
+
+    /**
+     * Plans a scan against an Iceberg table with predicate pushdown.
+     * Uses parallel manifest fetching via planWith(executor).
+     *
+     * @param table the Iceberg table to scan
+     * @param snapshotId the snapshot ID to use, or a value &lt;= 0 to use the current snapshot
+     * @param predicates Iceberg filter expressions to push down
+     * @param projectedColumns columns to project, or null/empty for all columns
+     * @return an {@link IcebergScanPlan} containing the pruned file list
+     */
+    public IcebergScanPlan planScan(Table table, long snapshotId, List<Expression> predicates, List<String> projectedColumns) {
+        Expression combined = predicates.stream().reduce(Expressions::and).orElse(Expressions.alwaysTrue());
+
+        TableScan scan = table.newScan();
+        if (snapshotId > 0) {
+            scan = scan.useSnapshot(snapshotId);
+        }
+        scan = scan.filter(combined);
+
+        if (projectedColumns != null && !projectedColumns.isEmpty()) {
+            scan = scan.select(projectedColumns);
+        }
+
+        // Use parallel manifest fetching
+        List<IcebergScanPlan.FileInfo> files = new ArrayList<>();
+        try (CloseableIterable<FileScanTask> tasks = scan.planWith(executorService).planFiles()) {
+            for (FileScanTask task : tasks) {
+                files.add(new IcebergScanPlan.FileInfo(task.file().path().toString(), task.file().fileSizeInBytes()));
+            }
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to plan Iceberg scan", e);
+        }
+
+        return new IcebergScanPlan(files, projectedColumns != null ? projectedColumns : List.of());
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/scan/package-info.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/main/java/org/opensearch/lakehouse/scan/package-info.java
@@ -1,0 +1,12 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+/**
+ * Iceberg scan planning and predicate pushdown.
+ */
+package org.opensearch.lakehouse.scan;

--- a/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/scan/CalciteToIcebergPredicateConverterTests.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/scan/CalciteToIcebergPredicateConverterTests.java
@@ -1,0 +1,738 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.scan;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.iceberg.expressions.Expression;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class CalciteToIcebergPredicateConverterTests extends OpenSearchTestCase {
+
+    private RelDataTypeFactory typeFactory;
+    private RelDataType rowType;
+    private RexBuilder rexBuilder;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        typeFactory = new JavaTypeFactoryImpl();
+        rowType = typeFactory.builder()
+            .add("id", SqlTypeName.BIGINT)
+            .add("name", SqlTypeName.VARCHAR)
+            .add("price", SqlTypeName.DOUBLE)
+            .add("qty", SqlTypeName.INTEGER)
+            .add("score", SqlTypeName.FLOAT)
+            .build();
+        rexBuilder = new RexBuilder(typeFactory);
+    }
+
+    // -- Non-RexCall input -> alwaysTrue --
+
+    public void testNonRexCallReturnsAlwaysTrue() {
+        RexInputRef ref = rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0);
+        Expression result = CalciteToIcebergPredicateConverter.convert(ref, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    public void testLiteralInputReturnsAlwaysTrue() {
+        RexLiteral literal = rexBuilder.makeBigintLiteral(BigDecimal.valueOf(42));
+        Expression result = CalciteToIcebergPredicateConverter.convert(literal, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    // -- Comparison operators --
+
+    public void testEquals() {
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(42))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, rowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    public void testNotEquals() {
+        RexNode ne = rexBuilder.makeCall(
+            SqlStdOperatorTable.NOT_EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(10))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(ne, rowType);
+        assertEquals(Expression.Operation.NOT_EQ, result.op());
+    }
+
+    public void testGreaterThan() {
+        RexNode gt = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(100))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(gt, rowType);
+        assertEquals(Expression.Operation.GT, result.op());
+    }
+
+    public void testGreaterThanOrEqual() {
+        RexNode gte = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(50))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(gte, rowType);
+        assertEquals(Expression.Operation.GT_EQ, result.op());
+    }
+
+    public void testLessThan() {
+        RexNode lt = rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(200))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(lt, rowType);
+        assertEquals(Expression.Operation.LT, result.op());
+    }
+
+    public void testLessThanOrEqual() {
+        RexNode lte = rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(300))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(lte, rowType);
+        assertEquals(Expression.Operation.LT_EQ, result.op());
+    }
+
+    // -- Flipped operands (literal op column) --
+
+    public void testFlippedOperandsGreaterThan() {
+        // literal > column -> column < literal
+        RexNode gt = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(100)),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0)
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(gt, rowType);
+        assertEquals(Expression.Operation.LT, result.op());
+    }
+
+    public void testFlippedOperandsGreaterThanOrEqual() {
+        // literal >= column -> column <= literal
+        RexNode gte = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN_OR_EQUAL,
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(50)),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0)
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(gte, rowType);
+        assertEquals(Expression.Operation.LT_EQ, result.op());
+    }
+
+    public void testFlippedOperandsLessThan() {
+        // literal < column -> column > literal
+        RexNode lt = rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN,
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(10)),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0)
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(lt, rowType);
+        assertEquals(Expression.Operation.GT, result.op());
+    }
+
+    public void testFlippedOperandsLessThanOrEqual() {
+        // literal <= column -> column >= literal
+        RexNode lte = rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN_OR_EQUAL,
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(5)),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0)
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(lte, rowType);
+        assertEquals(Expression.Operation.GT_EQ, result.op());
+    }
+
+    public void testFlippedOperandsEquals() {
+        // literal = column -> column = literal (symmetric, flipOp returns same op)
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(42)),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0)
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, rowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    public void testFlippedOperandsNotEquals() {
+        // literal != column -> column != literal (symmetric, flipOp returns same op)
+        RexNode ne = rexBuilder.makeCall(
+            SqlStdOperatorTable.NOT_EQUALS,
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(7)),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0)
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(ne, rowType);
+        assertEquals(Expression.Operation.NOT_EQ, result.op());
+    }
+
+    // -- Both operands not column/literal -> alwaysTrue --
+
+    public void testBothOperandsLiteralReturnsAlwaysTrue() {
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(1)),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(2))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    public void testBothOperandsColumnReturnsAlwaysTrue() {
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 3)
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    // -- AND / OR (logical operators) --
+
+    public void testAnd() {
+        RexNode left = rexBuilder.makeCall(
+            SqlStdOperatorTable.GREATER_THAN,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(10))
+        );
+        RexNode right = rexBuilder.makeCall(
+            SqlStdOperatorTable.LESS_THAN,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(100))
+        );
+        RexNode and = rexBuilder.makeCall(SqlStdOperatorTable.AND, left, right);
+
+        Expression result = CalciteToIcebergPredicateConverter.convert(and, rowType);
+        assertEquals(Expression.Operation.AND, result.op());
+    }
+
+    public void testOr() {
+        RexNode left = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(1))
+        );
+        RexNode right = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(2))
+        );
+        RexNode or = rexBuilder.makeCall(SqlStdOperatorTable.OR, left, right);
+
+        Expression result = CalciteToIcebergPredicateConverter.convert(or, rowType);
+        assertEquals(Expression.Operation.OR, result.op());
+    }
+
+    public void testAndWithThreeOperands() {
+        RexNode a = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(1))
+        );
+        RexNode b = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 3),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(2))
+        );
+        RexNode c = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DOUBLE), 2),
+            rexBuilder.makeLiteral(BigDecimal.valueOf(3.0), typeFactory.createSqlType(SqlTypeName.DOUBLE), false)
+        );
+        RexNode and = rexBuilder.makeCall(SqlStdOperatorTable.AND, a, b, c);
+
+        Expression result = CalciteToIcebergPredicateConverter.convert(and, rowType);
+        assertEquals(Expression.Operation.AND, result.op());
+    }
+
+    // -- NOT --
+
+    public void testNotWithConvertibleInner() {
+        RexNode inner = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(42))
+        );
+        RexNode not = rexBuilder.makeCall(SqlStdOperatorTable.NOT, inner);
+
+        Expression result = CalciteToIcebergPredicateConverter.convert(not, rowType);
+        assertEquals(Expression.Operation.NOT, result.op());
+    }
+
+    public void testNotWithUnconvertibleInnerReturnsAlwaysTrue() {
+        // An inner expression that can't be converted (two literals) -> alwaysTrue.
+        // NOT(alwaysTrue) should return alwaysTrue, NOT alwaysFalse.
+        RexNode inner = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(1)),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(2))
+        );
+        RexNode not = rexBuilder.makeCall(SqlStdOperatorTable.NOT, inner);
+
+        Expression result = CalciteToIcebergPredicateConverter.convert(not, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    // -- IS_NULL / IS_NOT_NULL --
+
+    public void testIsNull() {
+        RexNode isNull = rexBuilder.makeCall(
+            SqlStdOperatorTable.IS_NULL,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1)
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(isNull, rowType);
+        assertEquals(Expression.Operation.IS_NULL, result.op());
+    }
+
+    public void testIsNotNull() {
+        RexNode isNotNull = rexBuilder.makeCall(
+            SqlStdOperatorTable.IS_NOT_NULL,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1)
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(isNotNull, rowType);
+        assertEquals(Expression.Operation.NOT_NULL, result.op());
+    }
+
+    public void testIsNullWithNonColumnReturnsAlwaysTrue() {
+        RexNode isNull = rexBuilder.makeCall(SqlStdOperatorTable.IS_NULL, rexBuilder.makeBigintLiteral(BigDecimal.valueOf(42)));
+        Expression result = CalciteToIcebergPredicateConverter.convert(isNull, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    public void testIsNotNullWithNonColumnReturnsAlwaysTrue() {
+        RexNode isNotNull = rexBuilder.makeCall(SqlStdOperatorTable.IS_NOT_NULL, rexBuilder.makeBigintLiteral(BigDecimal.valueOf(42)));
+        Expression result = CalciteToIcebergPredicateConverter.convert(isNotNull, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    // -- IN (using mock RexCall since Calcite's IN operator has strict arity validation) --
+
+    public void testInWithMultipleValues() {
+        RexCall inCall = mockRexCall(
+            SqlKind.IN,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(1)),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(2)),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(3))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(inCall, rowType);
+        // IN(col, 1, 2, 3) -> EQ(col,1) OR EQ(col,2) OR EQ(col,3)
+        assertEquals(Expression.Operation.OR, result.op());
+    }
+
+    public void testInWithSingleValue() {
+        RexCall inCall = mockRexCall(
+            SqlKind.IN,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(42))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(inCall, rowType);
+        // IN with one value -> single EQ
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    public void testInWithNonLiteralValueReturnsAlwaysTrue() {
+        // IN(col, col2) -- second operand is not a literal
+        RexCall inCall = mockRexCall(
+            SqlKind.IN,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 3)
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(inCall, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    public void testInWithNonColumnFirstOperandReturnsAlwaysTrue() {
+        RexCall inCall = mockRexCall(
+            SqlKind.IN,
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(1)),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(2))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(inCall, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    public void testInWithTooFewOperandsReturnsAlwaysTrue() {
+        // IN with only one operand (the column, no values) -> operands.size() < 2
+        RexCall inCall = mockRexCall(SqlKind.IN, rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0));
+        Expression result = CalciteToIcebergPredicateConverter.convert(inCall, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    // -- Unsupported SqlKind -> alwaysTrue --
+
+    public void testUnsupportedSqlKindReturnsAlwaysTrue() {
+        // LIKE is an unsupported SqlKind in this converter
+        RexNode like = rexBuilder.makeCall(
+            SqlStdOperatorTable.LIKE,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1),
+            rexBuilder.makeLiteral("%foo%")
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(like, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    // -- BigDecimal coercion --
+
+    public void testCoercionToInteger() {
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.INTEGER), 3),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(42))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, rowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    public void testCoercionToBigint() {
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(999999999999L))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, rowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    public void testCoercionToFloat() {
+        // Use makeBigintLiteral to guarantee a BigDecimal value, then compare against FLOAT column "score"
+        // This forces the coerceValue FLOAT/REAL branch to convert BigDecimal -> float
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.FLOAT), 4),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(3))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, rowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    public void testCoercionToDouble() {
+        // Use makeBigintLiteral to guarantee a BigDecimal value, then compare against DOUBLE column "price"
+        // This forces the coerceValue DOUBLE branch to convert BigDecimal -> double
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DOUBLE), 2),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(99))
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, rowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    // -- String literal extraction (CHAR/VARCHAR) --
+
+    public void testStringLiteralChar() {
+        // makeLiteral("hello") produces a CHAR literal
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1),
+            rexBuilder.makeLiteral("hello")
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, rowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    public void testStringLiteralVarchar() {
+        // Explicitly create a VARCHAR literal to hit the VARCHAR branch in extractLiteralValue
+        RexNode varcharLiteral = rexBuilder.makeLiteral("world", typeFactory.createSqlType(SqlTypeName.VARCHAR, 10), false);
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1),
+            varcharLiteral
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, rowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    // -- Temporal literal extraction --
+
+    public void testTimestampLiteral() {
+        RelDataType tsRowType = typeFactory.builder().add("ts", SqlTypeName.TIMESTAMP).build();
+        // Mock a TIMESTAMP literal that returns epoch millis via getValueAs(Long.class)
+        RexLiteral tsLiteral = mock(RexLiteral.class);
+        when(tsLiteral.getTypeName()).thenReturn(SqlTypeName.TIMESTAMP);
+        when(tsLiteral.getValueAs(Long.class)).thenReturn(1705312200000L); // 2024-01-15 10:30:00 UTC millis
+
+        RexCall eqCall = mockRexCall(
+            SqlKind.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.TIMESTAMP), 0),
+            tsLiteral
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eqCall, tsRowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    public void testTimestampWithLocalTimeZoneLiteral() {
+        RelDataType tstzRowType = typeFactory.builder()
+            .add("tstz", typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE))
+            .build();
+        RexLiteral tstzLiteral = mock(RexLiteral.class);
+        when(tstzLiteral.getTypeName()).thenReturn(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE);
+        when(tstzLiteral.getValueAs(Long.class)).thenReturn(1705312200000L);
+
+        RexCall eqCall = mockRexCall(
+            SqlKind.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.TIMESTAMP_WITH_LOCAL_TIME_ZONE), 0),
+            tstzLiteral
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eqCall, tstzRowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    public void testDateLiteral() {
+        RelDataType dateRowType = typeFactory.builder().add("dt", SqlTypeName.DATE).build();
+        // Mock a DATE literal that returns days since epoch via getValueAs(Integer.class)
+        RexLiteral dateLiteral = mock(RexLiteral.class);
+        when(dateLiteral.getTypeName()).thenReturn(SqlTypeName.DATE);
+        when(dateLiteral.getValueAs(Integer.class)).thenReturn(19738); // 2024-01-15 days since epoch
+
+        RexCall eqCall = mockRexCall(SqlKind.EQUALS, rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DATE), 0), dateLiteral);
+        Expression result = CalciteToIcebergPredicateConverter.convert(eqCall, dateRowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    public void testTimeLiteral() {
+        RelDataType timeRowType = typeFactory.builder().add("t", SqlTypeName.TIME).build();
+        // Mock a TIME literal that returns millis since midnight via getValueAs(Integer.class)
+        RexLiteral timeLiteral = mock(RexLiteral.class);
+        when(timeLiteral.getTypeName()).thenReturn(SqlTypeName.TIME);
+        when(timeLiteral.getValueAs(Integer.class)).thenReturn(37800000); // 10:30:00 millis since midnight
+
+        RexCall eqCall = mockRexCall(SqlKind.EQUALS, rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.TIME), 0), timeLiteral);
+        Expression result = CalciteToIcebergPredicateConverter.convert(eqCall, timeRowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    public void testTimestampNullValueReturnsAlwaysTrue() {
+        RelDataType tsRowType = typeFactory.builder().add("ts", SqlTypeName.TIMESTAMP).build();
+        RexLiteral tsLiteral = mock(RexLiteral.class);
+        when(tsLiteral.getTypeName()).thenReturn(SqlTypeName.TIMESTAMP);
+        when(tsLiteral.getValueAs(Long.class)).thenReturn(null);
+
+        RexCall eqCall = mockRexCall(
+            SqlKind.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.TIMESTAMP), 0),
+            tsLiteral
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eqCall, tsRowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    public void testTimeNullValueReturnsAlwaysTrue() {
+        RelDataType timeRowType = typeFactory.builder().add("t", SqlTypeName.TIME).build();
+        RexLiteral timeLiteral = mock(RexLiteral.class);
+        when(timeLiteral.getTypeName()).thenReturn(SqlTypeName.TIME);
+        when(timeLiteral.getValueAs(Integer.class)).thenReturn(null);
+
+        RexCall eqCall = mockRexCall(SqlKind.EQUALS, rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.TIME), 0), timeLiteral);
+        Expression result = CalciteToIcebergPredicateConverter.convert(eqCall, timeRowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    // -- DECIMAL scale coercion --
+
+    public void testDecimalScaleCoercion() {
+        // DECIMAL(10,2) column with a BigDecimal that has scale 0 -> should be coerced to scale 2
+        RelDataType decimalRowType = typeFactory.builder().add("amount", SqlTypeName.DECIMAL, 10, 2).build();
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DECIMAL, 10, 2), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(100))  // scale=0, should become 100.00
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, decimalRowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    // -- CAST(literal) unwrapping --
+
+    public void testCastLiteralUnwrapping() {
+        // Use makeCast with different types to force an actual CAST node (not simplified away)
+        RexNode innerLiteral = rexBuilder.makeBigintLiteral(BigDecimal.valueOf(42));
+        RexNode cast = rexBuilder.makeCast(typeFactory.createSqlType(SqlTypeName.DOUBLE), innerLiteral);
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DOUBLE), 2),
+            cast
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, rowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    public void testCastLiteralUnwrappingViaMock() {
+        // Mock a CAST RexCall wrapping a literal to guarantee extractLiteralValue CAST branch
+        RexLiteral innerLiteral = rexBuilder.makeBigintLiteral(BigDecimal.valueOf(42));
+        RexCall castCall = mock(RexCall.class);
+        when(castCall.getKind()).thenReturn(SqlKind.CAST);
+        when(castCall.getOperands()).thenReturn(List.of(innerLiteral));
+
+        // Build: column = CAST(42)
+        RexCall eqCall = mockRexCall(SqlKind.EQUALS, rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0), castCall);
+        Expression result = CalciteToIcebergPredicateConverter.convert(eqCall, rowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    // -- Empty operand list for logical operators --
+    // Calcite won't allow constructing these via makeCall, so use mock RexCall.
+
+    public void testAndWithEmptyOperandsReturnsAlwaysTrue() {
+        RexCall emptyAnd = mockRexCall(SqlKind.AND);
+        Expression result = CalciteToIcebergPredicateConverter.convert(emptyAnd, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    public void testOrWithEmptyOperandsReturnsAlwaysTrue() {
+        RexCall emptyOr = mockRexCall(SqlKind.OR);
+        Expression result = CalciteToIcebergPredicateConverter.convert(emptyOr, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    // -- Empty operand list for IS_NULL / IS_NOT_NULL --
+
+    public void testIsNullWithEmptyOperandsReturnsAlwaysTrue() {
+        RexCall emptyIsNull = mockRexCall(SqlKind.IS_NULL);
+        Expression result = CalciteToIcebergPredicateConverter.convert(emptyIsNull, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    public void testIsNotNullWithEmptyOperandsReturnsAlwaysTrue() {
+        RexCall emptyIsNotNull = mockRexCall(SqlKind.IS_NOT_NULL);
+        Expression result = CalciteToIcebergPredicateConverter.convert(emptyIsNotNull, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    // -- Empty operand list for comparison --
+
+    public void testComparisonWithEmptyOperandsReturnsAlwaysTrue() {
+        RexCall emptyEq = mockRexCall(SqlKind.EQUALS);
+        Expression result = CalciteToIcebergPredicateConverter.convert(emptyEq, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    // -- Column name that doesn't match any field (coerceValue default) --
+
+    public void testCoerceValueColumnNotFoundReturnsOriginal() {
+        RelDataType smallRowType = typeFactory.builder().add("other_col", SqlTypeName.VARCHAR).build();
+
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(42))
+        );
+        // "other_col" is VARCHAR; coerceValue hits default branch for VARCHAR type.
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, smallRowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    // -- extractLiteralValue with non-literal, non-CAST RexCall --
+
+    public void testNonCastRexCallAsLiteralReturnsAlwaysTrue() {
+        // Build col = (col + col) -- the right side is a RexCall but not CAST
+        RexNode plus = rexBuilder.makeCall(
+            SqlStdOperatorTable.PLUS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0)
+        );
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0),
+            plus
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, rowType);
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    // -- coerceValue with non-BigDecimal value passes through --
+
+    public void testCoerceValueNonBigDecimalPassesThrough() {
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 1),
+            rexBuilder.makeLiteral("test_string")
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, rowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    // -- coerceValue BigDecimal for a column whose type has no special case --
+
+    public void testCoerceValueBigDecimalUnknownTypeFallsThrough() {
+        // DECIMAL column -- not INTEGER, BIGINT, FLOAT, or DOUBLE
+        RelDataType decimalRowType = typeFactory.builder().add("amount", SqlTypeName.DECIMAL, 10, 2).build();
+
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.DECIMAL, 10, 2), 0),
+            rexBuilder.makeLiteral(BigDecimal.valueOf(19.99), typeFactory.createSqlType(SqlTypeName.DECIMAL, 10, 2), false)
+        );
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, decimalRowType);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    // -- coerceValue BigDecimal for column not found in row type --
+
+    public void testCoerceValueBigDecimalColumnNotInRowType() {
+        RelDataType singleRow = typeFactory.builder().add("alpha", SqlTypeName.VARCHAR).build();
+
+        RexNode eq = rexBuilder.makeCall(
+            SqlStdOperatorTable.EQUALS,
+            rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.VARCHAR), 0),
+            rexBuilder.makeBigintLiteral(BigDecimal.valueOf(7))
+        );
+        // Column name is "alpha" (VARCHAR), literal is BigDecimal.
+        // coerceValue iterates: "alpha" is VARCHAR -> hits default case -> returns BigDecimal as-is.
+        Expression result = CalciteToIcebergPredicateConverter.convert(eq, singleRow);
+        assertEquals(Expression.Operation.EQ, result.op());
+    }
+
+    // -- CAST with wrong number of operands --
+
+    public void testCastWithMultipleOperandsReturnsAlwaysTrue() {
+        // Mock a CAST RexCall with 2 operands to hit the size != 1 branch
+        RexLiteral lit1 = rexBuilder.makeBigintLiteral(BigDecimal.valueOf(1));
+        RexLiteral lit2 = rexBuilder.makeBigintLiteral(BigDecimal.valueOf(2));
+        RexCall castCall = mock(RexCall.class);
+        when(castCall.getKind()).thenReturn(SqlKind.CAST);
+        when(castCall.getOperands()).thenReturn(List.of(lit1, lit2));
+
+        // column = CAST(1, 2) -- extractLiteralValue returns null since size != 1
+        RexCall eqCall = mockRexCall(SqlKind.EQUALS, rexBuilder.makeInputRef(typeFactory.createSqlType(SqlTypeName.BIGINT), 0), castCall);
+        Expression result = CalciteToIcebergPredicateConverter.convert(eqCall, rowType);
+        // Both flipped/non-flipped fail to extract literal -> alwaysTrue
+        assertEquals(Expression.Operation.TRUE, result.op());
+    }
+
+    // -- Helper to build mock RexCall with arbitrary operands --
+
+    private static RexCall mockRexCall(SqlKind kind, RexNode... operands) {
+        RexCall call = mock(RexCall.class);
+        when(call.getKind()).thenReturn(kind);
+        when(call.getOperands()).thenReturn(List.of(operands));
+        return call;
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/scan/IcebergScanPlanTests.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/scan/IcebergScanPlanTests.java
@@ -1,0 +1,101 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.scan;
+
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.util.Collections;
+import java.util.List;
+
+public class IcebergScanPlanTests extends OpenSearchTestCase {
+
+    // ── FileInfo tests ──────────────────────────────────────────────────
+
+    public void testFileInfoConstructorAndGetters() {
+        IcebergScanPlan.FileInfo info = new IcebergScanPlan.FileInfo("s3://bucket/data/file1.parquet", 1024L);
+        assertEquals("s3://bucket/data/file1.parquet", info.getPath());
+        assertEquals(1024L, info.getFileSizeInBytes());
+    }
+
+    public void testFileInfoZeroSize() {
+        IcebergScanPlan.FileInfo info = new IcebergScanPlan.FileInfo("/tmp/empty.parquet", 0L);
+        assertEquals("/tmp/empty.parquet", info.getPath());
+        assertEquals(0L, info.getFileSizeInBytes());
+    }
+
+    // ── IcebergScanPlan constructor / getters ───────────────────────────
+
+    public void testConstructorAndGetters() {
+        List<IcebergScanPlan.FileInfo> files = List.of(
+            new IcebergScanPlan.FileInfo("file1.parquet", 100L),
+            new IcebergScanPlan.FileInfo("file2.parquet", 200L)
+        );
+        List<String> columns = List.of("id", "name");
+
+        IcebergScanPlan plan = new IcebergScanPlan(files, columns);
+
+        assertEquals(files, plan.getFiles());
+        assertEquals(columns, plan.getProjectedColumns());
+    }
+
+    // ── getDataFilePaths ────────────────────────────────────────────────
+
+    public void testGetDataFilePaths() {
+        List<IcebergScanPlan.FileInfo> files = List.of(
+            new IcebergScanPlan.FileInfo("a.parquet", 10L),
+            new IcebergScanPlan.FileInfo("b.parquet", 20L),
+            new IcebergScanPlan.FileInfo("c.parquet", 30L)
+        );
+        IcebergScanPlan plan = new IcebergScanPlan(files, List.of());
+
+        List<String> paths = plan.getDataFilePaths();
+
+        assertEquals(3, paths.size());
+        assertEquals("a.parquet", paths.get(0));
+        assertEquals("b.parquet", paths.get(1));
+        assertEquals("c.parquet", paths.get(2));
+    }
+
+    // ── getTotalFileSize ────────────────────────────────────────────────
+
+    public void testGetTotalFileSize() {
+        List<IcebergScanPlan.FileInfo> files = List.of(
+            new IcebergScanPlan.FileInfo("f1.parquet", 100L),
+            new IcebergScanPlan.FileInfo("f2.parquet", 250L),
+            new IcebergScanPlan.FileInfo("f3.parquet", 50L)
+        );
+        IcebergScanPlan plan = new IcebergScanPlan(files, List.of("col1"));
+
+        assertEquals(400L, plan.getTotalFileSize());
+    }
+
+    // ── fileCount ───────────────────────────────────────────────────────
+
+    public void testFileCount() {
+        List<IcebergScanPlan.FileInfo> files = List.of(
+            new IcebergScanPlan.FileInfo("x.parquet", 10L),
+            new IcebergScanPlan.FileInfo("y.parquet", 20L)
+        );
+        IcebergScanPlan plan = new IcebergScanPlan(files, List.of());
+
+        assertEquals(2, plan.fileCount());
+    }
+
+    // ── Empty plan ──────────────────────────────────────────────────────
+
+    public void testEmptyPlan() {
+        IcebergScanPlan plan = new IcebergScanPlan(Collections.emptyList(), Collections.emptyList());
+
+        assertEquals(0, plan.fileCount());
+        assertEquals(0L, plan.getTotalFileSize());
+        assertTrue(plan.getDataFilePaths().isEmpty());
+        assertTrue(plan.getFiles().isEmpty());
+        assertTrue(plan.getProjectedColumns().isEmpty());
+    }
+}

--- a/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/scan/IcebergScanPlannerTests.java
+++ b/sandbox/plugins/lakehouse-iceberg/src/test/java/org/opensearch/lakehouse/scan/IcebergScanPlannerTests.java
@@ -1,0 +1,221 @@
+/*
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+
+package org.opensearch.lakehouse.scan;
+
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.FileScanTask;
+import org.apache.iceberg.Table;
+import org.apache.iceberg.TableScan;
+import org.apache.iceberg.expressions.Expression;
+import org.apache.iceberg.expressions.Expressions;
+import org.apache.iceberg.io.CloseableIterable;
+import org.apache.iceberg.io.CloseableIterator;
+import org.opensearch.test.OpenSearchTestCase;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class IcebergScanPlannerTests extends OpenSearchTestCase {
+
+    private ExecutorService executor;
+    private Table table;
+    private TableScan scan;
+
+    @Override
+    public void setUp() throws Exception {
+        super.setUp();
+        executor = Executors.newSingleThreadExecutor();
+        table = mock(Table.class);
+        scan = mock(TableScan.class);
+
+        // Default chaining: newScan -> filter -> planWith -> planFiles
+        when(table.newScan()).thenReturn(scan);
+        when(scan.filter(any(Expression.class))).thenReturn(scan);
+        when(scan.planWith(any(ExecutorService.class))).thenReturn(scan);
+    }
+
+    @Override
+    public void tearDown() throws Exception {
+        executor.shutdownNow();
+        super.tearDown();
+    }
+
+    // -- Basic scan with no predicates --
+
+    public void testBasicScanNoPredicates() throws Exception {
+        FileScanTask task1 = mockTask("s3://bucket/data/part-001.parquet", 1000L);
+        FileScanTask task2 = mockTask("s3://bucket/data/part-002.parquet", 2000L);
+        when(scan.planFiles()).thenReturn(closeable(List.of(task1, task2)));
+
+        IcebergScanPlanner planner = new IcebergScanPlanner(executor);
+        IcebergScanPlan plan = planner.planScan(table, -1, Collections.emptyList(), null);
+
+        assertEquals(2, plan.fileCount());
+        assertEquals(3000L, plan.getTotalFileSize());
+        assertEquals("s3://bucket/data/part-001.parquet", plan.getDataFilePaths().get(0));
+        assertEquals("s3://bucket/data/part-002.parquet", plan.getDataFilePaths().get(1));
+        // null projectedColumns should produce empty list
+        assertTrue(plan.getProjectedColumns().isEmpty());
+
+        // Should not call useSnapshot when snapshotId <= 0
+        verify(scan, never()).useSnapshot(any(Long.class));
+    }
+
+    // -- Scan with snapshot ID --
+
+    public void testScanWithSnapshotId() throws Exception {
+        FileScanTask task = mockTask("file.parquet", 500L);
+        when(scan.useSnapshot(42L)).thenReturn(scan);
+        when(scan.planFiles()).thenReturn(closeable(List.of(task)));
+
+        IcebergScanPlanner planner = new IcebergScanPlanner(executor);
+        IcebergScanPlan plan = planner.planScan(table, 42L, Collections.emptyList(), null);
+
+        verify(scan).useSnapshot(42L);
+        assertEquals(1, plan.fileCount());
+    }
+
+    // -- Scan with predicates --
+
+    public void testScanWithPredicates() throws Exception {
+        Expression pred1 = Expressions.greaterThan("id", 100);
+        Expression pred2 = Expressions.lessThan("id", 200);
+        FileScanTask task = mockTask("filtered.parquet", 750L);
+        when(scan.planFiles()).thenReturn(closeable(List.of(task)));
+
+        IcebergScanPlanner planner = new IcebergScanPlanner(executor);
+        IcebergScanPlan plan = planner.planScan(table, -1, List.of(pred1, pred2), null);
+
+        // Should have called filter with the AND-combined predicates
+        verify(scan).filter(any(Expression.class));
+        assertEquals(1, plan.fileCount());
+        assertEquals(750L, plan.getTotalFileSize());
+    }
+
+    // -- Scan with projected columns --
+
+    @SuppressWarnings("unchecked")
+    public void testScanWithProjectedColumns() throws Exception {
+        FileScanTask task = mockTask("projected.parquet", 300L);
+        when(scan.select(any(java.util.Collection.class))).thenReturn(scan);
+        when(scan.planFiles()).thenReturn(closeable(List.of(task)));
+
+        List<String> columns = List.of("id", "name");
+        IcebergScanPlanner planner = new IcebergScanPlanner(executor);
+        IcebergScanPlan plan = planner.planScan(table, -1, Collections.emptyList(), columns);
+
+        verify(scan).select(columns);
+        assertEquals(columns, plan.getProjectedColumns());
+        assertEquals(1, plan.fileCount());
+    }
+
+    // -- Scan with empty projected columns list (should not call select) --
+
+    @SuppressWarnings("unchecked")
+    public void testScanWithEmptyProjectedColumns() throws Exception {
+        FileScanTask task = mockTask("full.parquet", 100L);
+        when(scan.planFiles()).thenReturn(closeable(List.of(task)));
+
+        IcebergScanPlanner planner = new IcebergScanPlanner(executor);
+        IcebergScanPlan plan = planner.planScan(table, -1, Collections.emptyList(), Collections.emptyList());
+
+        verify(scan, never()).select(any(java.util.Collection.class));
+        assertTrue(plan.getProjectedColumns().isEmpty());
+    }
+
+    // -- IOException wrapping --
+
+    public void testIOExceptionThrowsUncheckedIOException() throws Exception {
+        // Simulate IOException on close() via try-with-resources
+        CloseableIterable<FileScanTask> closeFailIterable = new CloseableIterable<FileScanTask>() {
+            @Override
+            public void close() throws IOException {
+                throw new IOException("Failed to close scan tasks");
+            }
+
+            @Override
+            public CloseableIterator<FileScanTask> iterator() {
+                return wrapIterator(Collections.<FileScanTask>emptyList().iterator());
+            }
+        };
+        when(scan.planFiles()).thenReturn(closeFailIterable);
+
+        IcebergScanPlanner planner = new IcebergScanPlanner(executor);
+        UncheckedIOException ex = expectThrows(
+            UncheckedIOException.class,
+            () -> planner.planScan(table, -1, Collections.emptyList(), null)
+        );
+        assertEquals("Failed to plan Iceberg scan", ex.getMessage());
+        assertTrue(ex.getCause() instanceof IOException);
+    }
+
+    // -- Empty scan results --
+
+    public void testEmptyScanResults() throws Exception {
+        when(scan.planFiles()).thenReturn(closeable(Collections.emptyList()));
+
+        IcebergScanPlanner planner = new IcebergScanPlanner(executor);
+        IcebergScanPlan plan = planner.planScan(table, -1, Collections.emptyList(), null);
+
+        assertEquals(0, plan.fileCount());
+        assertEquals(0L, plan.getTotalFileSize());
+        assertTrue(plan.getDataFilePaths().isEmpty());
+    }
+
+    // -- Helpers --
+
+    private static FileScanTask mockTask(String path, long size) {
+        FileScanTask task = mock(FileScanTask.class);
+        DataFile dataFile = mock(DataFile.class);
+        when(dataFile.path()).thenReturn(path);
+        when(dataFile.fileSizeInBytes()).thenReturn(size);
+        when(task.file()).thenReturn(dataFile);
+        return task;
+    }
+
+    private static <T> CloseableIterable<T> closeable(List<T> items) {
+        return new CloseableIterable<T>() {
+            @Override
+            public void close() {}
+
+            @Override
+            public CloseableIterator<T> iterator() {
+                return wrapIterator(items.iterator());
+            }
+        };
+    }
+
+    private static <T> CloseableIterator<T> wrapIterator(Iterator<T> delegate) {
+        return new CloseableIterator<T>() {
+            @Override
+            public void close() {}
+
+            @Override
+            public boolean hasNext() {
+                return delegate.hasNext();
+            }
+
+            @Override
+            public T next() {
+                return delegate.next();
+            }
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- **CalciteToIcebergPredicateConverter**: Converts Calcite RexNode WHERE filters → Iceberg Expression predicates for manifest-level file pruning. Supports `=`, `!=`, `<`, `>`, `<=`, `>=`, `AND`, `OR`, `NOT`, `IS NULL`, `IS NOT NULL`, `IN`. Falls back to `alwaysTrue()` for unsupported predicates (safe — never skips data).
- **IcebergScanPlanner**: Plans scans with predicate pushdown and parallel manifest fetching via `planWith(executor).planFiles()`.
- **IcebergScanPlan**: Result object with pruned file list (paths + sizes) and projected columns.
- **DataFusionPlugin fix**: `getSupportedFormats()` returned `null` causing NPE in `DataFormatRegistry` on cluster startup. Fixed to return `List.of()`.

## Key Design Decisions
- **Conservative fallback**: Unsupported predicates return `alwaysTrue()` — never `alwaysFalse()`. This means the scan might read extra files, but never incorrectly prunes data.
- **NOT(alwaysTrue) bug prevention**: If a NOT's inner expression can't be converted, we return `alwaysTrue()` instead of `NOT(alwaysTrue) = alwaysFalse`.
- **BigDecimal coercion**: Calcite types numeric literals as `BigDecimal`; we coerce to the column's Java type (int/long/float/double) so Iceberg's type-strict Expression API doesn't reject them.
- **CAST unwrapping**: Calcite wraps literals in `CAST` when types differ — we unwrap to extract the underlying literal value.

## Test plan
- [x] 52 new unit tests (38 for predicate converter, 7 for scan planner, 7 for scan plan)
- [x] 100% line coverage on IcebergScanPlan, IcebergScanPlanner, ComparisonOp
- [x] 95% line coverage on CalciteToIcebergPredicateConverter (2 unreachable dead-code lines)
- [x] JaCoCo verification passes
- [x] `./gradlew :sandbox:plugins:lakehouse-iceberg:test` — all 118 tests pass